### PR TITLE
feat: add three js configurator scaffold

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,1 +1,66 @@
-
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>3D Configurator</title>
+  <style>
+    body,html{margin:0;padding:0;height:100%;overflow:hidden;font-family:sans-serif;}
+    #container{display:flex;height:100%;}
+    #slotsPanel,#objectsPanel{width:20%;background:#f4f4f4;overflow-y:auto;padding:10px;}
+    #slotsPanel{border-right:1px solid #ccc;}
+    #objectsPanel{border-left:1px solid #ccc;}
+    #viewer{flex:1;position:relative;}
+    canvas{display:block;}
+    #exportBtn{position:absolute;bottom:10px;left:50%;transform:translateX(-50%);}
+    #transformModeBtn{position:absolute;top:10px;left:50%;transform:translateX(-50%);}
+    #objectModal{position:fixed;top:10%;left:50%;transform:translateX(-50%);width:60%;max-height:80%;background:white;border:1px solid #ccc;overflow:auto;display:none;padding:20px;z-index:10;}
+    #objectModal .object-item{display:flex;align-items:center;margin-bottom:10px;cursor:pointer;}
+    #objectModal img{width:80px;height:80px;object-fit:cover;margin-right:10px;}
+    #objectModal .pagination{display:flex;justify-content:center;margin-top:10px;}
+    .slot{display:flex;align-items:center;justify-content:space-between;margin-bottom:5px;cursor:pointer;}
+    .slot.selected{background:#ddd;}
+    .slot button{margin-left:5px;}
+    .obj-card{border:1px solid #ccc;padding:5px;margin-bottom:5px;}
+    .obj-card.selected{background:#e0e0e0;}
+    .material-list{display:flex;flex-wrap:wrap;}
+    .material-list button{border:none;background:none;padding:0;margin:2px;cursor:pointer;}
+    .material-list img{width:40px;height:40px;object-fit:cover;}
+  </style>
+  <script type="importmap">
+  {
+    "imports": {
+      "three": "https://unpkg.com/three@0.165.0/build/three.module.js",
+      "OrbitControls": "https://unpkg.com/three@0.165.0/examples/jsm/controls/OrbitControls.js",
+      "GLTFLoader": "https://unpkg.com/three@0.165.0/examples/jsm/loaders/GLTFLoader.js",
+      "TransformControls": "https://unpkg.com/three@0.165.0/examples/jsm/controls/TransformControls.js"
+    }
+  }
+  </script>
+</head>
+<body>
+  <div id="container">
+    <div id="slotsPanel">
+      <button id="addSlotBtn">Add slot</button>
+      <ul id="slots"></ul>
+    </div>
+    <div id="viewer">
+      <button id="transformModeBtn">Toggle Transform</button>
+      <button id="exportBtn">Export JSON</button>
+    </div>
+    <div id="objectsPanel">
+      <button id="addObjectBtn">Add object</button>
+      <div id="objects"></div>
+    </div>
+  </div>
+  <div id="objectModal">
+    <div id="modalList"></div>
+    <div class="pagination">
+      <button id="prevPage">Prev</button>
+      <span id="pageInfo"></span>
+      <button id="nextPage">Next</button>
+    </div>
+    <button id="closeModal">Close</button>
+  </div>
+  <script type="module" src="./js/main.js"></script>
+</body>
+</html>

--- a/js/api.js
+++ b/js/api.js
@@ -1,0 +1,10 @@
+export async function fetchObjects(page = 1) {
+  try {
+    const res = await fetch(`https://api.vizbl.us/obj/GetPublic?page=${page}`);
+    if (!res.ok) throw new Error('Network response was not ok');
+    return await res.json();
+  } catch (err) {
+    console.error('API error', err);
+    return { objs: [], pages_count: 0 };
+  }
+}

--- a/js/main.js
+++ b/js/main.js
@@ -1,0 +1,183 @@
+import * as THREE from 'three';
+import { OrbitControls } from 'OrbitControls';
+import { GLTFLoader } from 'GLTFLoader';
+import { TransformControls } from 'TransformControls';
+import { ConfiguratorState } from './state.js';
+import { renderSlots, renderObjects } from './ui.js';
+import { openObjectModal } from './modal.js';
+
+const state = new ConfiguratorState();
+
+const slotListEl = document.getElementById('slots');
+const addSlotBtn = document.getElementById('addSlotBtn');
+const addObjectBtn = document.getElementById('addObjectBtn');
+const objectsContainer = document.getElementById('objects');
+const exportBtn = document.getElementById('exportBtn');
+const modalEl = document.getElementById('objectModal');
+const transformBtn = document.getElementById('transformModeBtn');
+
+// THREE.js setup
+const viewer = document.getElementById('viewer');
+const renderer = new THREE.WebGLRenderer({ antialias: true });
+renderer.setSize(viewer.clientWidth, viewer.clientHeight);
+viewer.appendChild(renderer.domElement);
+const scene = new THREE.Scene();
+scene.background = new THREE.Color(0xffffff);
+const camera = new THREE.PerspectiveCamera(60, viewer.clientWidth / viewer.clientHeight, 0.1, 1000);
+camera.position.set(0, 1, 3);
+const orbit = new OrbitControls(camera, renderer.domElement);
+const loader = new GLTFLoader();
+const transform = new TransformControls(camera, renderer.domElement);
+transform.addEventListener('dragging-changed', e => { orbit.enabled = !e.value; });
+scene.add(transform);
+
+window.addEventListener('resize', () => {
+  renderer.setSize(viewer.clientWidth, viewer.clientHeight);
+  camera.aspect = viewer.clientWidth / viewer.clientHeight;
+  camera.updateProjectionMatrix();
+});
+
+const meshes = {};
+
+function animate() {
+  requestAnimationFrame(animate);
+  renderer.render(scene, camera);
+}
+animate();
+
+function updateScene() {
+  Object.keys(meshes).forEach(id => {
+    scene.remove(meshes[id]);
+    if (transform.object === meshes[id]) transform.detach();
+    delete meshes[id];
+  });
+  state.slots.forEach(slot => {
+    if (slot.selectedObjectIndex !== -1) {
+      const obj = slot.objects[slot.selectedObjectIndex];
+      loadObject(slot, obj);
+    }
+  });
+}
+
+function loadObject(slot, obj) {
+  const mat = obj.materials[obj.selectedMaterial];
+  const url = mat?.native?.glbUrl;
+  if (!url) return;
+  loader.load(url, gltf => {
+    const mesh = gltf.scene;
+    mesh.position.fromArray(obj.transform.position);
+    mesh.rotation.set(
+      THREE.MathUtils.degToRad(obj.transform.rotation[0]),
+      THREE.MathUtils.degToRad(obj.transform.rotation[1]),
+      THREE.MathUtils.degToRad(obj.transform.rotation[2])
+    );
+    mesh.scale.fromArray(obj.transform.scale);
+    scene.add(mesh);
+    meshes[slot.id] = mesh;
+    attachTransform(mesh, obj);
+  });
+}
+
+function attachTransform(mesh, obj) {
+  transform.attach(mesh);
+  transform.enabled = transform.mode !== undefined && transform.mode !== '';
+  transform.addEventListener('objectChange', () => {
+    obj.transform.position = [mesh.position.x, mesh.position.y, mesh.position.z];
+    obj.transform.rotation = [
+      THREE.MathUtils.radToDeg(mesh.rotation.x),
+      THREE.MathUtils.radToDeg(mesh.rotation.y),
+      THREE.MathUtils.radToDeg(mesh.rotation.z)
+    ];
+    obj.transform.scale = [mesh.scale.x, mesh.scale.y, mesh.scale.z];
+  });
+}
+
+// UI callbacks
+const slotCallbacks = {
+  onSelect(index) {
+    state.currentSlotIndex = index;
+    renderSlots(state, slotListEl, slotCallbacks);
+    renderObjects(state.currentSlot, objectsContainer, objectCallbacks);
+    updateScene();
+  },
+  onDelete(id) {
+    state.removeSlot(id);
+    renderSlots(state, slotListEl, slotCallbacks);
+    renderObjects(state.currentSlot, objectsContainer, objectCallbacks);
+    updateScene();
+  }
+};
+
+const objectCallbacks = {
+  onSelectObject(index) {
+    state.currentSlot.selectedObjectIndex = index;
+    renderObjects(state.currentSlot, objectsContainer, objectCallbacks);
+    updateScene();
+  },
+  onSelectMaterial(objIndex, matIndex) {
+    const slot = state.currentSlot;
+    const obj = slot.objects[objIndex];
+    obj.selectedMaterial = matIndex;
+    if (slot.selectedObjectIndex === objIndex) {
+      loadObject(slot, obj);
+    }
+  },
+  onDelete(objIndex) {
+    const slot = state.currentSlot;
+    slot.objects.splice(objIndex, 1);
+    if (slot.selectedObjectIndex >= slot.objects.length) {
+      slot.selectedObjectIndex = slot.objects.length - 1;
+    }
+    renderObjects(slot, objectsContainer, objectCallbacks);
+    updateScene();
+  }
+};
+
+addSlotBtn.addEventListener('click', () => {
+  state.addSlot();
+  renderSlots(state, slotListEl, slotCallbacks);
+  renderObjects(state.currentSlot, objectsContainer, objectCallbacks);
+});
+
+addObjectBtn.addEventListener('click', () => {
+  if (!state.currentSlot) return;
+  openObjectModal(modalEl, {
+    onSelect(objData) {
+      state.addObjectToCurrent(objData);
+      renderObjects(state.currentSlot, objectsContainer, objectCallbacks);
+      updateScene();
+    }
+  });
+});
+
+exportBtn.addEventListener('click', () => {
+  const json = state.exportJSON();
+  const blob = new Blob([json], { type: 'application/json' });
+  const a = document.createElement('a');
+  a.href = URL.createObjectURL(blob);
+  a.download = 'config.json';
+  a.click();
+  URL.revokeObjectURL(a.href);
+});
+
+let transformMode = null;
+transformBtn.addEventListener('click', () => {
+  if (transformMode === null) {
+    transformMode = 'translate';
+    transform.setMode('translate');
+    transform.enabled = true;
+  } else if (transformMode === 'translate') {
+    transformMode = 'rotate';
+    transform.setMode('rotate');
+  } else {
+    transformMode = null;
+    transform.enabled = false;
+    transform.detach();
+  }
+});
+
+// initialize
+state.addSlot();
+renderSlots(state, slotListEl, slotCallbacks);
+renderObjects(state.currentSlot, objectsContainer, objectCallbacks);
+updateScene();

--- a/js/modal.js
+++ b/js/modal.js
@@ -1,0 +1,57 @@
+import { fetchObjects } from './api.js';
+
+export function openObjectModal(modalEl, { onSelect }) {
+  const listEl = modalEl.querySelector('#modalList');
+  const pageInfo = modalEl.querySelector('#pageInfo');
+  const prevBtn = modalEl.querySelector('#prevPage');
+  const nextBtn = modalEl.querySelector('#nextPage');
+  const closeBtn = modalEl.querySelector('#closeModal');
+  let currentPage = 1;
+  let totalPages = 1;
+
+  async function load(page) {
+    const data = await fetchObjects(page);
+    listEl.innerHTML = '';
+    data.objs.forEach(obj => {
+      const item = document.createElement('div');
+      item.className = 'object-item';
+      const img = document.createElement('img');
+      img.src = obj.preview?.subRes?.small || obj.preview?.url || '';
+      const span = document.createElement('span');
+      span.textContent = obj.name;
+      item.appendChild(img);
+      item.appendChild(span);
+      item.addEventListener('click', () => {
+        onSelect(obj);
+        close();
+      });
+      listEl.appendChild(item);
+    });
+    currentPage = page;
+    totalPages = data.pages_count || 1;
+    pageInfo.textContent = `${currentPage}/${totalPages}`;
+    prevBtn.disabled = currentPage <= 1;
+    nextBtn.disabled = currentPage >= totalPages;
+  }
+
+  function close() {
+    modalEl.style.display = 'none';
+    prevBtn.removeEventListener('click', prev);
+    nextBtn.removeEventListener('click', next);
+    closeBtn.removeEventListener('click', close);
+  }
+
+  function prev() {
+    if (currentPage > 1) load(currentPage - 1);
+  }
+  function next() {
+    if (currentPage < totalPages) load(currentPage + 1);
+  }
+
+  prevBtn.addEventListener('click', prev);
+  nextBtn.addEventListener('click', next);
+  closeBtn.addEventListener('click', close);
+
+  modalEl.style.display = 'block';
+  load(1);
+}

--- a/js/state.js
+++ b/js/state.js
@@ -1,0 +1,66 @@
+export class ConfiguratorState {
+  constructor() {
+    this.slots = [];
+    this.currentSlotIndex = -1;
+  }
+
+  addSlot(name = 'New slot') {
+    const slot = {
+      id: crypto.randomUUID(),
+      name,
+      objects: [],
+      selectedObjectIndex: -1
+    };
+    this.slots.push(slot);
+    this.currentSlotIndex = this.slots.length - 1;
+    return slot;
+  }
+
+  removeSlot(id) {
+    const idx = this.slots.findIndex(s => s.id === id);
+    if (idx !== -1) {
+      this.slots.splice(idx, 1);
+      if (this.currentSlotIndex >= this.slots.length) {
+        this.currentSlotIndex = this.slots.length - 1;
+      }
+    }
+  }
+
+  get currentSlot() {
+    return this.slots[this.currentSlotIndex];
+  }
+
+  addObjectToCurrent(objectData) {
+    if (!this.currentSlot) return null;
+    const obj = {
+      uuid: objectData.uuid,
+      name: objectData.name,
+      materials: objectData.materials || [],
+      selectedMaterial: 0,
+      transform: {
+        position: [0, 0, 0],
+        rotation: [0, 0, 0],
+        scale: [1, 1, 1]
+      }
+    };
+    this.currentSlot.objects.push(obj);
+    this.currentSlot.selectedObjectIndex = this.currentSlot.objects.length - 1;
+    return obj;
+  }
+
+  exportJSON() {
+    const slotsOut = {};
+    this.slots.forEach(slot => {
+      slotsOut[slot.id] = {
+        name: slot.name,
+        objects: slot.objects.map(o => ({
+          uuid: o.uuid,
+          position: o.transform.position,
+          rotation: o.transform.rotation,
+          scale: o.transform.scale
+        }))
+      };
+    });
+    return JSON.stringify({ slots: slotsOut }, null, 2);
+  }
+}

--- a/js/ui.js
+++ b/js/ui.js
@@ -1,0 +1,63 @@
+export function renderSlots(state, container, { onSelect, onDelete }) {
+  container.innerHTML = '';
+  state.slots.forEach((slot, index) => {
+    const li = document.createElement('li');
+    li.className = 'slot' + (index === state.currentSlotIndex ? ' selected' : '');
+    const nameSpan = document.createElement('span');
+    nameSpan.textContent = slot.name;
+    nameSpan.addEventListener('click', () => {
+      if (state.currentSlotIndex === index) {
+        const newName = prompt('Rename slot', slot.name);
+        if (newName) {
+          slot.name = newName;
+          renderSlots(state, container, { onSelect, onDelete });
+        }
+      } else {
+        onSelect(index);
+      }
+    });
+    const delBtn = document.createElement('button');
+    delBtn.textContent = 'X';
+    delBtn.addEventListener('click', e => {
+      e.stopPropagation();
+      onDelete(slot.id);
+    });
+    li.appendChild(nameSpan);
+    li.appendChild(delBtn);
+    container.appendChild(li);
+  });
+}
+
+export function renderObjects(slot, container, { onSelectObject, onSelectMaterial, onDelete }) {
+  container.innerHTML = '';
+  if (!slot) return;
+  slot.objects.forEach((obj, objIndex) => {
+    const card = document.createElement('div');
+    card.className = 'obj-card' + (objIndex === slot.selectedObjectIndex ? ' selected' : '');
+    const title = document.createElement('div');
+    title.textContent = obj.name;
+    title.addEventListener('click', () => onSelectObject(objIndex));
+    const delBtn = document.createElement('button');
+    delBtn.textContent = 'Delete';
+    delBtn.addEventListener('click', () => onDelete(objIndex));
+    const matList = document.createElement('div');
+    matList.className = 'material-list';
+    obj.materials.forEach((mat, matIndex) => {
+      const btn = document.createElement('button');
+      const img = document.createElement('img');
+      const url = mat.previews?.[0]?.subRes?.small || mat.previews?.[0]?.url;
+      img.src = url || '';
+      img.alt = mat.name;
+      btn.appendChild(img);
+      btn.addEventListener('click', e => {
+        e.stopPropagation();
+        onSelectMaterial(objIndex, matIndex);
+      });
+      matList.appendChild(btn);
+    });
+    card.appendChild(title);
+    card.appendChild(delBtn);
+    card.appendChild(matList);
+    container.appendChild(card);
+  });
+}


### PR DESCRIPTION
## Summary
- scaffold Three.js scene with slot and object panels
- add state management and API-driven object selection
- enable transform controls and JSON export

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6895693faecc8322bc8546c552325c84