### PR TITLE
feat: filter slots by step and simplify viewer

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,1 +1,95 @@
-
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>3D Configurator</title>
+  <link rel="stylesheet" href="styles.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet" />
+  <script type="importmap">
+  {
+    "imports": {
+      "three": "https://unpkg.com/three@0.165.0/build/three.module.js",
+      "OrbitControls": "https://unpkg.com/three@0.165.0/examples/jsm/controls/OrbitControls.js",
+      "GLTFLoader": "https://unpkg.com/three@0.165.0/examples/jsm/loaders/GLTFLoader.js",
+      "RGBELoader": "https://unpkg.com/three@0.165.0/examples/jsm/loaders/RGBELoader.js",
+      "TransformControls": "https://unpkg.com/three@0.165.0/examples/jsm/controls/TransformControls.js",
+      "EffectComposer": "https://unpkg.com/three@0.165.0/examples/jsm/postprocessing/EffectComposer.js",
+      "RenderPass": "https://unpkg.com/three@0.165.0/examples/jsm/postprocessing/RenderPass.js",
+      "OutlinePass": "https://unpkg.com/three@0.165.0/examples/jsm/postprocessing/OutlinePass.js",
+      "ShaderPass": "https://unpkg.com/three@0.165.0/examples/jsm/postprocessing/ShaderPass.js",
+      "FXAAShader": "https://unpkg.com/three@0.165.0/examples/jsm/shaders/FXAAShader.js",
+      "OutputPass": "https://unpkg.com/three@0.165.0/examples/jsm/postprocessing/OutputPass.js"
+    }
+  }
+  </script>
+</head>
+<body>
+  <div id="container">
+    <div id="slotsPanel">
+      <div id="stepControls">
+        <button id="prevStep">Prev</button>
+        <span id="stepName"></span>
+        <button id="nextStep">Next</button>
+        <button id="delStep" class="action-btn">Delete step</button>
+      </div>
+      <button id="addSlotBtn" class="action-btn">Add slot</button>
+      <ul id="slots"></ul>
+    </div>
+    <div id="viewer">
+      <div id="transformBtns">
+        <button id="moveBtn">Move</button>
+        <button id="rotateBtn">Rotate</button>
+        <button id="noneBtn">None</button>
+      </div>
+      <div id="coordsPanel">
+        <input type="number" id="coordX" step="0.01" />
+        <input type="number" id="coordY" step="0.01" />
+        <input type="number" id="coordZ" step="0.01" />
+      </div>
+      <div id="bottomBtns">
+        <button id="exportBtn">Export JSON</button>
+        <button id="importBtn">Import JSON</button>
+        <button id="stepsBtn">Steps</button>
+        <input type="file" id="importInput" accept="application/json" style="display:none" />
+      </div>
+      <button id="outlineBtn" class="action-btn">Outline</button>
+      <button id="gridBtn" class="action-btn">Grid</button>
+    </div>
+    <div id="objectsPanel">
+      <div id="objectActions">
+        <button id="addObjectBtn" class="action-btn">Add object</button>
+        <button id="inheritBtn" class="action-btn">Inherit first</button>
+      </div>
+      <label id="canEmptyRow"><input type="checkbox" id="canBeEmpty"> Can be empty</label>
+      <div id="objects"></div>
+    </div>
+  </div>
+  <div id="objectModal">
+    <div class="modal-box">
+      <div id="modalList"></div>
+      <div class="pagination">
+        <button id="prevPage">Prev</button>
+        <span id="pageInfo"></span>
+        <button id="nextPage">Next</button>
+      </div>
+    </div>
+    <button id="closeModal">Close</button>
+  </div>
+  <div id="stepsModal">
+    <div class="modal-box">
+      <div id="stepsList"></div>
+      <button id="addStep">Add step</button>
+      <button id="saveSteps">Save</button>
+    </div>
+    <button id="closeSteps">Close</button>
+  </div>
+  <div id="loadingOverlay">
+    <div class="loading-box">
+      <p>Loading</p>
+      <div class="progress"><div id="progressBar"></div></div>
+    </div>
+  </div>
+  <script type="module" src="./js/main.js"></script>
+</body>
+</html>

--- a/js/api.js
+++ b/js/api.js
@@ -1,0 +1,25 @@
+export async function fetchObjects(page = 1) {
+  try {
+    const res = await fetch(`https://api.vizbl.us/obj/GetPublic?page=${page}`);
+    if (!res.ok) throw new Error('Network response was not ok');
+    return await res.json();
+  } catch (err) {
+    console.error('API error', err);
+    return { objs: [], pages_count: 0 };
+  }
+}
+
+export async function fetchObjectDetails(uuid) {
+  try {
+    const res = await fetch('https://api.vizbl.us/obj/Fetch', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ uuid })
+    });
+    if (!res.ok) throw new Error('Network response was not ok');
+    return await res.json();
+  } catch (err) {
+    console.error('API error', err);
+    return null;
+  }
+}

--- a/js/main.js
+++ b/js/main.js
@@ -1,0 +1,579 @@
+import * as THREE from 'three';
+import { OrbitControls } from 'OrbitControls';
+import { GLTFLoader } from 'GLTFLoader';
+import { RGBELoader } from 'RGBELoader';
+import { TransformControls } from 'TransformControls';
+import { EffectComposer } from 'EffectComposer';
+import { RenderPass } from 'RenderPass';
+import { OutlinePass } from 'OutlinePass';
+import { ShaderPass } from 'ShaderPass';
+import { FXAAShader } from 'FXAAShader';
+import { OutputPass } from 'OutputPass';
+import { ConfiguratorState } from './state.js';
+import { renderSlots, renderObjects, renderSlotsMobile } from './ui.js';
+import { openObjectModal, openStepsModal } from './modal.js';
+import { fetchObjectDetails } from './api.js';
+
+const state = new ConfiguratorState();
+
+const slotListEl = document.getElementById('slots');
+const addSlotBtn = document.getElementById('addSlotBtn');
+const prevStepBtn = document.getElementById('prevStep');
+const nextStepBtn = document.getElementById('nextStep');
+const stepNameEl = document.getElementById('stepName');
+const delStepBtn = document.getElementById('delStep');
+const stepControls = document.getElementById('stepControls');
+const addObjectBtn = document.getElementById('addObjectBtn');
+const inheritBtn = document.getElementById('inheritBtn');
+const objectsContainer = document.getElementById('objects');
+const canBeEmptyChk = document.getElementById('canBeEmpty');
+const exportBtn = document.getElementById('exportBtn');
+const importBtn = document.getElementById('importBtn');
+const importInput = document.getElementById('importInput');
+const stepsBtn = document.getElementById('stepsBtn');
+const stepsModal = document.getElementById('stepsModal');
+const modalEl = document.getElementById('objectModal');
+const moveBtn = document.getElementById('moveBtn');
+const rotateBtn = document.getElementById('rotateBtn');
+const noneBtn = document.getElementById('noneBtn');
+const gridBtn = document.getElementById('gridBtn');
+const outlineBtn = document.getElementById('outlineBtn');
+const coordsPanel = document.getElementById('coordsPanel');
+const coordX = document.getElementById('coordX');
+const coordY = document.getElementById('coordY');
+const coordZ = document.getElementById('coordZ');
+const loadingOverlay = document.getElementById('loadingOverlay');
+const progressBar = document.getElementById('progressBar');
+outlineBtn.classList.add('active');
+
+// THREE.js setup
+const viewer = document.getElementById('viewer');
+const renderer = new THREE.WebGLRenderer({ antialias: true });
+renderer.setSize(viewer.clientWidth, viewer.clientHeight);
+renderer.outputEncoding = THREE.sRGBEncoding;
+renderer.toneMapping = THREE.LinearToneMapping;
+renderer.physicallyCorrectLights = true;
+renderer.setClearColor(0xffffff, 1);
+viewer.appendChild(renderer.domElement);
+const scene = new THREE.Scene();
+const pmrem = new THREE.PMREMGenerator(renderer);
+new RGBELoader().load(
+  'https://raw.githubusercontent.com/donmccurdy/three-gltf-viewer/master/assets/environment/neutral.hdr',
+  (hdr) => {
+    const envMap = pmrem.fromEquirectangular(hdr).texture;
+    scene.environment = envMap;
+    scene.background = envMap;
+    hdr.dispose();
+    pmrem.dispose();
+  }
+);
+const camera = new THREE.PerspectiveCamera(60, viewer.clientWidth / viewer.clientHeight, 0.1, 1000);
+camera.position.set(0, 1, 3);
+const orbit = new OrbitControls(camera, renderer.domElement);
+const loader = new GLTFLoader();
+const transform = new TransformControls(camera, renderer.domElement);
+transform.addEventListener('dragging-changed', e => { orbit.enabled = !e.value; });
+const gizmoScene = new THREE.Scene();
+gizmoScene.add(transform);
+
+// postprocessing for hover outline
+const composer = new EffectComposer(renderer);
+composer.setSize(viewer.clientWidth, viewer.clientHeight);
+const renderPass = new RenderPass(scene, camera);
+composer.addPass(renderPass);
+const outlinePass = new OutlinePass(
+  new THREE.Vector2(viewer.clientWidth, viewer.clientHeight),
+  scene,
+  camera
+);
+outlinePass.edgeStrength = 2;
+outlinePass.edgeThickness = 1;
+outlinePass.visibleEdgeColor.set(0x008efa);
+outlinePass.hiddenEdgeColor.set(0xffffff);
+// ensure the outline blends normally over the scene
+outlinePass.overlayMaterial.blending = THREE.NormalBlending;
+outlinePass.overlayMaterial.transparent = true;
+composer.addPass(outlinePass);
+const outputPass = new OutputPass();
+composer.addPass(outputPass);
+const effectFXAA = new ShaderPass(FXAAShader);
+effectFXAA.uniforms['resolution'].value.set(1 / viewer.clientWidth, 1 / viewer.clientHeight);
+composer.addPass(effectFXAA);
+
+// lighting similar to gltf-viewer defaults
+const ambientLight = new THREE.AmbientLight(0xffffff, 0.3);
+scene.add(ambientLight);
+const dirLight = new THREE.DirectionalLight(0xffffff, 2.5);
+dirLight.position.set(5, 10, 7.5);
+scene.add(dirLight);
+
+const grid = new THREE.GridHelper(10, 10);
+grid.visible = false;
+scene.add(grid);
+
+const raycaster = new THREE.Raycaster();
+const pointer = new THREE.Vector2();
+let pointerDown = null;
+let pointerMoved = false;
+let hovered = null;
+
+function isMobile(){
+  return window.innerWidth <= 768;
+}
+
+function handleResize(){
+  renderer.setSize(viewer.clientWidth, viewer.clientHeight);
+  composer.setSize(viewer.clientWidth, viewer.clientHeight);
+  effectFXAA.uniforms['resolution'].value.set(1 / viewer.clientWidth, 1 / viewer.clientHeight);
+  camera.aspect = viewer.clientWidth / viewer.clientHeight;
+  camera.updateProjectionMatrix();
+  renderUI();
+}
+
+window.addEventListener('resize', handleResize);
+
+const meshes = {};
+let transformMode = null;
+
+const axisNames = ['x','y','z'];
+
+function updateCoordInputs(){
+  if (transformMode === null || !transform.object) {
+    coordsPanel.style.display = 'none';
+    return;
+  }
+  coordsPanel.style.display = 'flex';
+  if (transformMode === 'translate') {
+    coordX.value = transform.object.position.x.toFixed(2);
+    coordY.value = transform.object.position.y.toFixed(2);
+    coordZ.value = transform.object.position.z.toFixed(2);
+  } else if (transformMode === 'rotate') {
+    coordX.value = THREE.MathUtils.radToDeg(transform.object.rotation.x).toFixed(1);
+    coordY.value = THREE.MathUtils.radToDeg(transform.object.rotation.y).toFixed(1);
+    coordZ.value = THREE.MathUtils.radToDeg(transform.object.rotation.z).toFixed(1);
+  }
+}
+
+[coordX, coordY, coordZ].forEach((input, idx) => {
+  input.addEventListener('focus', () => input.select());
+  input.addEventListener('change', () => {
+    if (!transform.object) return;
+    const val = parseFloat(input.value);
+    if (isNaN(val)) return;
+    const obj = transform.object.userData.stateObj;
+    if (transformMode === 'translate') {
+      transform.object.position[axisNames[idx]] = val;
+      obj.transform.position[idx] = val;
+    } else if (transformMode === 'rotate') {
+      const rad = THREE.MathUtils.degToRad(val);
+      transform.object.rotation[axisNames[idx]] = rad;
+      obj.transform.rotation[idx] = val;
+    }
+    updateCoordInputs();
+  });
+});
+
+function showLoading(){
+  loadingOverlay.style.display='flex';
+  progressBar.style.width='0%';
+}
+
+function updateLoading(p){
+  progressBar.style.width = `${Math.round(p*100)}%`;
+}
+
+function hideLoading(){
+  loadingOverlay.style.display='none';
+}
+
+function animate() {
+  requestAnimationFrame(animate);
+  composer.render();
+  renderer.autoClear = false;
+  renderer.render(gizmoScene, camera);
+  renderer.autoClear = true;
+}
+animate();
+
+// track transform changes for the currently attached object
+transform.addEventListener('objectChange', () => {
+  const obj = transform.object?.userData?.stateObj;
+  if (!obj) return;
+  obj.transform.position = [transform.object.position.x, transform.object.position.y, transform.object.position.z];
+  obj.transform.rotation = [
+    THREE.MathUtils.radToDeg(transform.object.rotation.x),
+    THREE.MathUtils.radToDeg(transform.object.rotation.y),
+    THREE.MathUtils.radToDeg(transform.object.rotation.z)
+  ];
+  obj.transform.scale = [transform.object.scale.x, transform.object.scale.y, transform.object.scale.z];
+  updateCoordInputs();
+});
+
+function loadObject(slot, obj, attach = false) {
+  const mat = obj.materials[obj.selectedMaterial];
+  const url = mat?.native?.glbUrl;
+  if (!url) return;
+  const loadId = crypto.randomUUID();
+  slot._loadId = loadId;
+  showLoading();
+  loader.load(
+    url,
+    gltf => {
+      if (slot._loadId !== loadId) { hideLoading(); return; }
+      const mesh = gltf.scene;
+      mesh.position.fromArray(obj.transform.position);
+      mesh.rotation.set(
+        THREE.MathUtils.degToRad(obj.transform.rotation[0]),
+        THREE.MathUtils.degToRad(obj.transform.rotation[1]),
+        THREE.MathUtils.degToRad(obj.transform.rotation[2])
+      );
+      mesh.scale.fromArray(obj.transform.scale);
+      mesh.userData.stateObj = obj;
+      mesh.userData.slotId = slot.id;
+      scene.add(mesh);
+      meshes[slot.id] = mesh;
+      if (attach && transformMode !== null) attachTransformControls(mesh, obj);
+      hideLoading();
+    },
+    xhr => {
+      if (xhr.total) updateLoading(xhr.loaded / xhr.total);
+    },
+    err => {
+      console.error('Load error', err);
+      hideLoading();
+    }
+  );
+}
+
+function loadSlot(slot, attach = false) {
+  const existing = meshes[slot.id];
+  if (existing) {
+    if (transform.object === existing) transform.detach();
+    scene.remove(existing);
+    delete meshes[slot.id];
+  }
+  if (slot.hidden || slot.selectedObjectIndex === -1) {
+    updateCoordInputs();
+    return;
+  }
+  const obj = slot.objects[slot.selectedObjectIndex];
+  loadObject(slot, obj, attach && transformMode !== null);
+}
+
+function attachTransformControls(mesh, obj) {
+  if (transformMode === null) return;
+  mesh.userData.stateObj = obj;
+  transform.attach(mesh);
+  transform.enabled = true;
+  updateCoordInputs();
+}
+
+function activateSlot(slot) {
+  if (transformMode === null) {
+    transform.detach();
+  }
+  if (!slot || slot.selectedObjectIndex === -1 || slot.hidden) {
+    transform.detach();
+    updateCoordInputs();
+    return;
+  }
+  const mesh = meshes[slot.id];
+  if (mesh) {
+    if (transformMode !== null) transform.attach(mesh);
+  } else {
+    loadSlot(slot, transformMode !== null);
+  }
+  transform.enabled = transformMode !== null;
+  updateCoordInputs();
+}
+
+function setHovered(obj) {
+  if (hovered === obj) return;
+  hovered = obj;
+  outlinePass.selectedObjects = obj ? [obj] : [];
+}
+
+function handleHover(event) {
+  const rect = renderer.domElement.getBoundingClientRect();
+  pointer.x = ((event.clientX - rect.left) / rect.width) * 2 - 1;
+  pointer.y = -((event.clientY - rect.top) / rect.height) * 2 + 1;
+  raycaster.setFromCamera(pointer, camera);
+  const intersect = raycaster.intersectObjects(Object.values(meshes), true)[0];
+  let obj = intersect ? intersect.object : null;
+  while (obj && !obj.userData.slotId) obj = obj.parent;
+  setHovered(obj);
+}
+
+function handleSceneClick(event) {
+  const rect = renderer.domElement.getBoundingClientRect();
+  pointer.x = ((event.clientX - rect.left) / rect.width) * 2 - 1;
+  pointer.y = -((event.clientY - rect.top) / rect.height) * 2 + 1;
+  raycaster.setFromCamera(pointer, camera);
+  const intersect = raycaster.intersectObjects(Object.values(meshes), true)[0];
+  if (!intersect) return;
+  let obj = intersect.object;
+  while (obj && !obj.userData.slotId) obj = obj.parent;
+  if (!obj || !obj.userData.slotId) return;
+  const slotIndex = state.slots.findIndex(s => s.id === obj.userData.slotId);
+  if (slotIndex === -1) return;
+  const slot = state.slots[slotIndex];
+  const objIdx = slot.objects.indexOf(obj.userData.stateObj);
+  if (objIdx !== -1) slot.selectedObjectIndex = objIdx;
+  slotCallbacks.onSelect(slotIndex);
+}
+
+// UI callbacks
+const slotCallbacks = {
+  onSelect(index) {
+    state.currentSlotIndex = index;
+    const stepIdx = state.steps.findIndex(st=>st.id===state.slots[index].stepId);
+    if(stepIdx!==-1) state.currentStepIndex = stepIdx;
+    renderUI();
+    activateSlot(state.currentSlot);
+    const el = slotListEl.children[state.slots.filter(s=>s.stepId===state.currentStep.id).indexOf(state.currentSlot)];
+    if (el) el.scrollIntoView({ block: 'nearest' });
+  },
+  onDelete(id) {
+    const mesh = meshes[id];
+    if (mesh) {
+      if (transform.object === mesh) transform.detach();
+      scene.remove(mesh);
+      delete meshes[id];
+    }
+    state.removeSlot(id);
+    renderUI();
+    activateSlot(state.currentSlot);
+  },
+  onToggleHide(slot) {
+    slot.hidden = !slot.hidden;
+    const mesh = meshes[slot.id];
+    if (slot.hidden) {
+      if (mesh) {
+        if (transform.object === mesh) transform.detach();
+        scene.remove(mesh);
+        delete meshes[slot.id];
+      }
+    } else {
+      loadSlot(slot, slot === state.currentSlot);
+    }
+    renderUI();
+  }
+};
+
+const objectCallbacks = {
+  onSelectObject(index) {
+    const slot = state.currentSlot;
+    slot.selectedObjectIndex = index;
+    renderUI();
+    loadSlot(slot, true);
+  },
+  onSelectMaterial(objIndex, matIndex) {
+    const slot = state.currentSlot;
+    slot.selectedObjectIndex = objIndex;
+    const obj = slot.objects[objIndex];
+    obj.selectedMaterial = matIndex;
+    renderUI();
+    loadSlot(slot, true);
+  },
+  onDelete(objIndex) {
+    const slot = state.currentSlot;
+    slot.objects.splice(objIndex, 1);
+    if (slot.selectedObjectIndex >= slot.objects.length) {
+      slot.selectedObjectIndex = slot.objects.length - 1;
+    }
+    renderUI();
+    loadSlot(slot, true);
+  }
+};
+
+addSlotBtn.addEventListener('click', () => {
+  state.addSlot();
+  renderUI();
+  canBeEmptyChk.checked = state.currentSlot?.canBeEmpty || false;
+});
+
+addObjectBtn.addEventListener('click', () => {
+  if (!state.currentSlot) return;
+  openObjectModal(modalEl, {
+    async onSelect(objData) {
+      const details = await fetchObjectDetails(objData.uuid);
+      if (!details) return;
+      state.addObjectToCurrent(details);
+      renderUI();
+      loadSlot(state.currentSlot, true);
+    }
+  });
+});
+
+exportBtn.addEventListener('click', () => {
+  const json = state.exportJSON();
+  const blob = new Blob([json], { type: 'application/json' });
+  const a = document.createElement('a');
+  a.href = URL.createObjectURL(blob);
+  a.download = 'config.json';
+  a.click();
+  URL.revokeObjectURL(a.href);
+});
+
+importBtn.addEventListener('click', () => importInput.click());
+importInput.addEventListener('change', async e => {
+  const file = e.target.files[0];
+  if (!file) return;
+  try {
+    const text = await file.text();
+    const data = JSON.parse(text);
+    await handleImport(data);
+  } catch (err) {
+    console.error('Import failed', err);
+  }
+  importInput.value = '';
+});
+
+stepsBtn.addEventListener('click', () => {
+  openStepsModal(stepsModal, state, renderUI);
+});
+
+function changeStep(delta){
+  const len = state.steps.length;
+  state.currentStepIndex = (state.currentStepIndex + delta + len) % len;
+  const stepId = state.currentStep.id;
+  const idx = state.slots.findIndex(s=>s.stepId===stepId);
+  state.currentSlotIndex = idx;
+  renderUI();
+}
+
+prevStepBtn.addEventListener('click',()=>changeStep(-1));
+nextStepBtn.addEventListener('click',()=>changeStep(1));
+delStepBtn.addEventListener('click',()=>{
+  if(state.steps.length<=1) return;
+  const step = state.currentStep;
+  const idx = state.steps.indexOf(step);
+  state.steps.splice(idx,1);
+  state.slots.forEach(s=>{ if(s.stepId===step.id) s.stepId = state.steps[0].id; });
+  if(state.currentStepIndex>=state.steps.length) state.currentStepIndex=0;
+  renderUI();
+});
+
+function updateTransformButtons() {
+  moveBtn.classList.toggle('active', transformMode === 'translate');
+  rotateBtn.classList.toggle('active', transformMode === 'rotate');
+  noneBtn.classList.toggle('active', transformMode === null);
+}
+
+function setTransformMode(mode) {
+  if (mode === transformMode) {
+    if (mode === null) return; // already none
+    transformMode = null;
+  } else {
+    transformMode = mode;
+  }
+
+  if (transformMode === null) {
+    transform.enabled = false;
+    transform.detach();
+  } else {
+    transform.setMode(transformMode);
+    transform.enabled = true;
+    const mesh = transform.object || meshes[state.currentSlot?.id];
+    if (mesh) transform.attach(mesh);
+  }
+
+  updateTransformButtons();
+  updateCoordInputs();
+}
+
+moveBtn.addEventListener('click', () => setTransformMode('translate'));
+rotateBtn.addEventListener('click', () => setTransformMode('rotate'));
+noneBtn.addEventListener('click', () => setTransformMode(null));
+
+gridBtn.addEventListener('click', () => {
+  grid.visible = !grid.visible;
+  gridBtn.classList.toggle('active', grid.visible);
+});
+
+outlineBtn.addEventListener('click', () => {
+  outlinePass.enabled = !outlinePass.enabled;
+  outlineBtn.classList.toggle('active', outlinePass.enabled);
+});
+
+renderer.domElement.addEventListener('pointerdown', e => {
+  if (e.button !== 0) return;
+  pointerDown = { x: e.clientX, y: e.clientY };
+  pointerMoved = false;
+});
+
+renderer.domElement.addEventListener('pointermove', e => {
+  handleHover(e);
+  if (!pointerDown) return;
+  if (Math.abs(e.clientX - pointerDown.x) > 5 || Math.abs(e.clientY - pointerDown.y) > 5) {
+    pointerMoved = true;
+  }
+});
+
+renderer.domElement.addEventListener('pointerleave', () => {
+  setHovered(null);
+});
+
+renderer.domElement.addEventListener('pointerup', e => {
+  if (e.button !== 0 || !pointerDown) return;
+  if (!pointerMoved) handleSceneClick(e);
+  handleHover(e);
+  pointerDown = null;
+});
+
+inheritBtn.addEventListener('click', () => {
+  const slot = state.currentSlot;
+  state.inheritFromFirst(slot);
+  if (slot) loadSlot(slot, true);
+});
+
+canBeEmptyChk.addEventListener('change', () => {
+  const slot = state.currentSlot;
+  if (slot) slot.canBeEmpty = canBeEmptyChk.checked;
+});
+
+async function handleImport(data) {
+  Object.values(meshes).forEach(m => {
+    if (transform.object === m) transform.detach();
+    scene.remove(m);
+  });
+  Object.keys(meshes).forEach(k => delete meshes[k]);
+
+  setTransformMode(null);
+  await state.importJSON(data, fetchObjectDetails);
+
+  renderUI();
+  canBeEmptyChk.checked = state.currentSlot?.canBeEmpty || false;
+
+  state.slots.forEach((slot, idx) => {
+    loadSlot(slot, idx === state.currentSlotIndex);
+  });
+}
+
+// initialize
+state.addSlot();
+
+function renderUI(){
+  if(state.currentStepIndex>=state.steps.length) state.currentStepIndex = 0;
+  const step = state.currentStep;
+  stepNameEl.textContent = step.name;
+  stepControls.style.display = state.steps.length>1 ? 'flex' : 'none';
+  if(state.currentSlot?.stepId !== step.id){
+    const idx = state.slots.findIndex(s=>s.stepId===step.id);
+    state.currentSlotIndex = idx;
+  }
+  if(isMobile()){
+    objectsContainer.parentElement.style.display='none';
+    renderSlotsMobile(state, slotListEl, slotCallbacks, objectCallbacks, step.id);
+  }else{
+    objectsContainer.parentElement.style.display='block';
+    renderSlots(state, slotListEl, slotCallbacks, step.id);
+    renderObjects(state.currentSlot, objectsContainer, objectCallbacks);
+  }
+  canBeEmptyChk.checked = state.currentSlot?.canBeEmpty || false;
+}
+
+renderUI();
+canBeEmptyChk.checked = state.currentSlot?.canBeEmpty || false;
+activateSlot(state.currentSlot);
+updateTransformButtons();

--- a/js/modal.js
+++ b/js/modal.js
@@ -1,0 +1,200 @@
+import { fetchObjects } from './api.js';
+
+let lastPage = 1;
+
+export function openObjectModal(modalEl, { onSelect }) {
+  const listEl = modalEl.querySelector('#modalList');
+  const pageInfo = modalEl.querySelector('#pageInfo');
+  const prevBtn = modalEl.querySelector('#prevPage');
+  const nextBtn = modalEl.querySelector('#nextPage');
+  const closeBtn = modalEl.querySelector('#closeModal');
+  let currentPage = lastPage;
+  let totalPages = 1;
+
+  async function load(page) {
+    const data = await fetchObjects(page);
+    listEl.innerHTML = '';
+    data.objs.forEach(obj => {
+      const card = document.createElement('div');
+      card.className = 'modal-card';
+
+      const thumb = document.createElement('div');
+      thumb.className = 'thumb';
+      const img = document.createElement('img');
+      img.src = obj.preview?.subRes?.small || obj.preview?.url || '';
+      thumb.appendChild(img);
+      const overlay = document.createElement('div');
+      overlay.className = 'overlay';
+      const title = document.createElement('p');
+      title.textContent = obj.name;
+      thumb.appendChild(overlay);
+      thumb.appendChild(title);
+      card.appendChild(thumb);
+
+      const info = document.createElement('div');
+      info.className = 'info';
+
+      const owner = document.createElement('div');
+      owner.className = 'owner';
+      const avatar = document.createElement('span');
+      avatar.className = 'avatar';
+      avatar.textContent = obj.owner?.name ? obj.owner.name[0] : '';
+      owner.appendChild(avatar);
+      const ownerName = document.createElement('p');
+      ownerName.textContent = obj.owner?.name || '';
+      owner.appendChild(ownerName);
+      info.appendChild(owner);
+
+      const counts = document.createElement('div');
+      counts.className = 'counts';
+      const viewsWrap = document.createElement('div');
+      viewsWrap.className = 'count';
+      viewsWrap.innerHTML = `<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M21.8701 11.496C21.2301 10.386 17.7101 4.81597 11.7301 4.99597C6.20007 5.13597 3.00007 9.99597 2.13007 11.496C2.0423 11.648 1.99609 11.8204 1.99609 11.996C1.99609 12.1715 2.0423 12.3439 2.13007 12.496C2.76007 13.586 6.13007 18.996 12.0201 18.996H12.2701C17.8001 18.856 21.0101 13.996 21.8701 12.496C21.9577 12.3439 22.0039 12.1715 22.0039 11.996C22.0039 11.8204 21.9577 11.648 21.8701 11.496ZM12.0001 15.496C11.5355 15.5038 11.0741 15.4191 10.6426 15.2468C10.2112 15.0744 9.81833 14.8179 9.48704 14.4922C9.15575 14.1664 8.89263 13.778 8.71302 13.3495C8.53341 12.921 8.44091 12.4611 8.44091 11.9965C8.44091 11.5319 8.53341 11.0719 8.71302 10.6434C8.89263 10.2149 9.15575 9.8265 9.48704 9.50076C9.81833 9.17503 10.2112 8.91851 10.6426 8.74617C11.0741 8.57383 11.5355 8.48911 12.0001 8.49697C12.9283 8.49697 13.8186 8.86571 14.4749 9.52209C15.1313 10.1785 15.5001 11.0687 15.5001 11.997C15.5001 12.9252 15.1313 13.8155 14.4749 14.4718C13.8186 15.1282 12.9283 15.496 12.0001 15.496Z" fill="currentColor"></path></svg>`;
+      const viewsCount = document.createElement('p');
+      viewsCount.textContent = obj.viewsShowcase ?? obj.views ?? 0;
+      viewsWrap.appendChild(viewsCount);
+      counts.appendChild(viewsWrap);
+
+      const likesWrap = document.createElement('div');
+      likesWrap.className = 'count';
+      likesWrap.innerHTML = `<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M16.6011 3.12072C17.2514 3.15332 17.8923 3.29981 18.4951 3.55427C19.1836 3.84496 19.8093 4.27105 20.3362 4.80801L20.529 5.01393C20.9663 5.50534 21.3179 6.07062 21.5676 6.68471C21.853 7.38644 22 8.13895 22 8.89853C22 9.65809 21.853 10.4106 21.5676 11.1123C21.3559 11.633 21.0701 12.1178 20.7217 12.5529L20.6953 12.6902L20.5861 12.7892L20.0693 13.2592L19.411 13.9317L12.617 20.8529C12.2973 21.1786 11.7917 21.1995 11.4487 20.9146L11.3822 20.8529L3.6629 12.9882C2.59837 11.9035 2.00003 10.4325 2 8.89853C2.00006 7.36455 2.59828 5.8927 3.6629 4.80801C4.72748 3.72355 6.17147 3.11471 7.67689 3.11464C9.18247 3.11464 10.6271 3.72339 11.6917 4.80801L11.9996 5.12167L12.3074 4.80801C12.8345 4.27085 13.4607 3.84502 14.1494 3.55427C14.8382 3.2635 15.5767 3.11377 16.3223 3.11377L16.6011 3.12072Z" fill="currentColor"></path></svg>`;
+      const likesCount = document.createElement('p');
+      likesCount.textContent = obj.likes ?? 0;
+      likesWrap.appendChild(likesCount);
+      counts.appendChild(likesWrap);
+
+      info.appendChild(counts);
+      card.appendChild(info);
+
+      card.addEventListener('click', () => {
+        onSelect(obj);
+        close();
+      });
+
+      listEl.appendChild(card);
+    });
+    currentPage = page;
+    lastPage = currentPage;
+    totalPages = data.pages_count || 1;
+    pageInfo.textContent = `${currentPage}/${totalPages}`;
+    prevBtn.disabled = currentPage <= 1;
+    nextBtn.disabled = currentPage >= totalPages;
+  }
+
+  function close() {
+    modalEl.style.display = 'none';
+    prevBtn.removeEventListener('click', prev);
+    nextBtn.removeEventListener('click', next);
+    closeBtn.removeEventListener('click', close);
+  }
+
+  function prev() {
+    if (currentPage > 1) load(currentPage - 1);
+  }
+  function next() {
+    if (currentPage < totalPages) load(currentPage + 1);
+  }
+
+  prevBtn.addEventListener('click', prev);
+  nextBtn.addEventListener('click', next);
+  closeBtn.addEventListener('click', close);
+
+  modalEl.style.display = 'block';
+  load(currentPage);
+}
+
+export function openStepsModal(modalEl, state, onSave) {
+  const listEl = modalEl.querySelector('#stepsList');
+  const addBtn = modalEl.querySelector('#addStep');
+  const saveBtn = modalEl.querySelector('#saveSteps');
+  const closeBtn = modalEl.querySelector('#closeSteps');
+
+  function render() {
+    listEl.innerHTML = '';
+    state.steps.forEach((step) => {
+      const row = document.createElement('div');
+      row.className = 'step-row';
+      const header = document.createElement('div');
+      header.className = 'step-header';
+      const name = document.createElement('input');
+      name.value = step.name;
+      header.appendChild(name);
+      const del = document.createElement('button');
+      del.textContent = 'Delete';
+      del.className = 'action-btn';
+      del.addEventListener('click', () => {
+        if(state.steps.length<=1) return;
+        const idx = state.steps.indexOf(step);
+        const removed = state.steps.splice(idx,1)[0];
+        state.slots.forEach(s=>{ if(s.stepId===removed.id) s.stepId = state.steps[0].id; });
+        if(state.currentStepIndex>=state.steps.length) state.currentStepIndex=0;
+        render();
+      });
+      header.appendChild(del);
+      row.appendChild(header);
+      const checks = document.createElement('div');
+      checks.className = 'slot-checks';
+      state.slots.forEach((slot) => {
+        const label = document.createElement('label');
+        const chk = document.createElement('input');
+        chk.type = 'checkbox';
+        chk.checked = slot.stepId === step.id;
+        chk.dataset.slot = slot.id;
+        chk.addEventListener('change', () => {
+          if (chk.checked) {
+            listEl.querySelectorAll(`input[data-slot="${slot.id}"]`).forEach((other) => {
+              if (other !== chk) other.checked = false;
+            });
+          }
+        });
+        label.appendChild(chk);
+        label.appendChild(document.createTextNode(slot.name));
+        checks.appendChild(label);
+      });
+      row.appendChild(checks);
+      row._name = name;
+      listEl.appendChild(row);
+    });
+  }
+
+  function addStep() {
+    state.addStep(`Step ${state.steps.length + 1}`);
+    render();
+  }
+
+  function save() {
+    const rows = Array.from(listEl.children);
+    rows.forEach((row, idx) => {
+      const step = state.steps[idx];
+      step.name = row._name.value;
+      step.index = idx;
+    });
+    state.slots.forEach((slot) => {
+      const checked = listEl.querySelector(`input[data-slot="${slot.id}"]:checked`);
+      if (checked) {
+        const stepIdx = rows.indexOf(checked.closest('.step-row'));
+        slot.stepId = state.steps[stepIdx].id;
+      } else {
+        slot.stepId = state.steps[0].id;
+      }
+    });
+    modalEl.style.display = 'none';
+    addBtn.removeEventListener('click', addStep);
+    saveBtn.removeEventListener('click', save);
+    closeBtn.removeEventListener('click', close);
+    onSave();
+  }
+
+  function close() {
+    modalEl.style.display = 'none';
+    addBtn.removeEventListener('click', addStep);
+    saveBtn.removeEventListener('click', save);
+    closeBtn.removeEventListener('click', close);
+  }
+
+  addBtn.addEventListener('click', addStep);
+  saveBtn.addEventListener('click', save);
+  closeBtn.addEventListener('click', close);
+  modalEl.style.display = 'block';
+  render();
+}

--- a/js/state.js
+++ b/js/state.js
@@ -1,0 +1,160 @@
+export class ConfiguratorState {
+  constructor() {
+    const defaultStep = { id: crypto.randomUUID(), name: 'Step 1', index: 0 };
+    this.steps = [defaultStep];
+    this.slots = [];
+    this.currentSlotIndex = -1;
+    this.currentStepIndex = 0;
+  }
+
+  clear() {
+    const def = { id: crypto.randomUUID(), name: 'Step 1', index: 0 };
+    this.steps = [def];
+    this.slots = [];
+    this.currentSlotIndex = -1;
+    this.currentStepIndex = 0;
+  }
+
+  addSlot(name = 'New slot') {
+    const stepId = this.currentStep ? this.currentStep.id : this.steps[0].id;
+    const slot = {
+      id: crypto.randomUUID(),
+      name,
+      objects: [],
+      selectedObjectIndex: -1,
+      canBeEmpty: false,
+       hidden: false,
+       stepId
+    };
+    this.slots.push(slot);
+    this.currentSlotIndex = this.slots.length - 1;
+    return slot;
+  }
+
+  addSlotFromData(id, name, objects = [], canBeEmpty = false, stepId = this.steps[0].id) {
+    const slot = {
+      id,
+      name,
+      objects,
+      selectedObjectIndex: objects.length ? 0 : -1,
+      canBeEmpty,
+      hidden: false,
+      stepId
+    };
+    this.slots.push(slot);
+    if (this.currentSlotIndex === -1) {
+      this.currentSlotIndex = 0;
+    }
+    return slot;
+  }
+
+  removeSlot(id) {
+    const idx = this.slots.findIndex(s => s.id === id);
+    if (idx !== -1) {
+      this.slots.splice(idx, 1);
+      if (this.currentSlotIndex >= this.slots.length) {
+        this.currentSlotIndex = this.slots.length - 1;
+      }
+    }
+  }
+
+  get currentSlot() {
+    return this.slots[this.currentSlotIndex];
+  }
+
+  addObjectToCurrent(objectData) {
+    if (!this.currentSlot) return null;
+    const obj = {
+      uuid: objectData.uuid,
+      name: objectData.name,
+      materials: objectData.materials || [],
+      selectedMaterial: 0,
+      transform: {
+        position: [0, 0, 0],
+        rotation: [0, 0, 0],
+        scale: [1, 1, 1]
+      }
+    };
+    this.currentSlot.objects.push(obj);
+    this.currentSlot.selectedObjectIndex = this.currentSlot.objects.length - 1;
+    return obj;
+  }
+
+  inheritFromFirst(slot) {
+    if (!slot || slot.objects.length < 2) return;
+    const first = slot.objects[0];
+    slot.objects.slice(1).forEach(obj => {
+      obj.transform.position = [...first.transform.position];
+      obj.transform.rotation = [...first.transform.rotation];
+    });
+  }
+
+  addStep(name) {
+    const step = { id: crypto.randomUUID(), name, index: this.steps.length };
+    this.steps.push(step);
+    return step;
+  }
+
+  async importJSON(data, fetchDetails) {
+    this.clear();
+    this.steps = Object.entries(data.steps || {}).map(([id, s]) => ({
+      id,
+      name: s.name,
+      index: s.index || 0
+    }));
+    if (!this.steps.length) {
+      const def = { id: crypto.randomUUID(), name: 'Step 1', index: 0 };
+      this.steps = [def];
+    }
+    this.steps.sort((a, b) => a.index - b.index);
+    this.currentStepIndex = 0;
+    const entries = Object.entries(data.slots || {});
+    for (const [id, slotData] of entries) {
+      const objects = [];
+      for (const objData of slotData.objects || []) {
+        const details = await fetchDetails(objData.uuid);
+        if (!details) continue;
+        objects.push({
+          uuid: objData.uuid,
+          name: details.name,
+          materials: details.materials || [],
+          selectedMaterial: 0,
+          transform: {
+            position: objData.position || [0, 0, 0],
+            rotation: objData.rotation || [0, 0, 0],
+            scale: objData.scale || [1, 1, 1]
+          }
+        });
+      }
+      this.addSlotFromData(id, slotData.name, objects, slotData.canBeEmpty, slotData.step || this.steps[0].id);
+    }
+    const firstIdx = this.slots.findIndex(s=>s.stepId===this.currentStep.id);
+    this.currentSlotIndex = firstIdx;
+  }
+
+  get currentStep(){
+    return this.steps[this.currentStepIndex];
+  }
+
+  exportJSON() {
+    const stepsOut = {};
+    this.steps.forEach(step => {
+      stepsOut[step.id] = { name: step.name, index: step.index };
+    });
+    const slotsOut = {};
+    this.slots.forEach(slot => {
+      slotsOut[slot.id] = {
+        name: slot.name,
+        canBeEmpty: slot.canBeEmpty,
+        step: slot.stepId,
+        objects: slot.objects.map(o => ({
+          uuid: o.uuid,
+          position: o.transform.position,
+          rotation: o.transform.rotation,
+          scale: o.transform.scale
+        }))
+      };
+    });
+    return JSON.stringify({ steps: stepsOut, slots: slotsOut }, null, 2);
+  }
+}

--- a/js/ui.js
+++ b/js/ui.js
@@ -1,0 +1,140 @@
+export function renderSlots(state, container, { onSelect, onDelete, onToggleHide }, stepId) {
+  container.innerHTML = '';
+  state.slots.filter(s=>s.stepId===stepId).forEach((slot) => {
+    const index = state.slots.indexOf(slot);
+    const li = document.createElement('li');
+    li.className = 'slot' + (index === state.currentSlotIndex ? ' selected' : '');
+    li.addEventListener('click', () => {
+      if (state.currentSlotIndex === index) {
+        const newName = prompt('Rename slot', slot.name);
+          if (newName) {
+            slot.name = newName;
+            renderSlots(state, container, { onSelect, onDelete, onToggleHide });
+          }
+        } else {
+          onSelect(index);
+        }
+      });
+    const nameSpan = document.createElement('span');
+    nameSpan.textContent = slot.name;
+    const hideBtn = document.createElement('button');
+    hideBtn.textContent = 'Hide';
+    hideBtn.className = 'hide-btn' + (slot.hidden ? ' active' : '');
+    hideBtn.addEventListener('click', e => {
+      e.stopPropagation();
+      onToggleHide(slot);
+    });
+    const delBtn = document.createElement('button');
+    delBtn.textContent = 'X';
+    delBtn.className = 'action-btn';
+    delBtn.addEventListener('click', e => {
+      e.stopPropagation();
+      onDelete(slot.id);
+    });
+    const actions = document.createElement('div');
+    actions.className = 'slot-actions';
+    actions.appendChild(hideBtn);
+    actions.appendChild(delBtn);
+    li.appendChild(nameSpan);
+    li.appendChild(actions);
+    container.appendChild(li);
+  });
+}
+
+export function renderObjects(slot, container, { onSelectObject, onSelectMaterial, onDelete }) {
+  container.innerHTML = '';
+  if (!slot) return;
+  slot.objects.forEach((obj, objIndex) => {
+    const card = document.createElement('div');
+    card.className = 'obj-card' + (objIndex === slot.selectedObjectIndex ? ' selected' : '');
+    const title = document.createElement('div');
+    title.textContent = obj.name;
+    title.addEventListener('click', () => onSelectObject(objIndex));
+    const delBtn = document.createElement('button');
+    delBtn.textContent = 'Delete';
+    delBtn.className = 'action-btn';
+    delBtn.addEventListener('click', () => onDelete(objIndex));
+    const matList = document.createElement('div');
+    matList.className = 'material-list';
+    obj.materials.forEach((mat, matIndex) => {
+      const btn = document.createElement('button');
+      const img = document.createElement('img');
+      const url = mat.previews?.[0]?.subRes?.small || mat.previews?.[0]?.url;
+      img.src = url || '';
+      img.alt = mat.name;
+      btn.appendChild(img);
+      btn.addEventListener('click', e => {
+        e.stopPropagation();
+        onSelectMaterial(objIndex, matIndex);
+      });
+      if (objIndex === slot.selectedObjectIndex && matIndex === obj.selectedMaterial) {
+        btn.classList.add('selected');
+      }
+      matList.appendChild(btn);
+    });
+    card.appendChild(title);
+    card.appendChild(delBtn);
+    card.appendChild(matList);
+    container.appendChild(card);
+  });
+}
+
+export function renderSlotsMobile(state, container, slotCallbacks, objectCallbacks, stepId){
+  container.innerHTML='';
+  state.slots.filter(s=>s.stepId===stepId).forEach((slot)=>{
+    const index = state.slots.indexOf(slot);
+    const det=document.createElement('details');
+    det.className='slot-mobile';
+    det.open = slot._mobileOpen || false;
+    det.addEventListener('toggle',()=>{slot._mobileOpen = det.open;});
+    const sum=document.createElement('summary');
+    sum.textContent=slot.name;
+    sum.addEventListener('click',e=>{
+      if(state.currentSlotIndex===index){
+        if(e.detail===2){
+          const newName=prompt('Rename slot',slot.name);
+          if(newName){slot.name=newName;renderSlotsMobile(state,container,slotCallbacks,objectCallbacks,stepId);} }
+      }else{
+        slotCallbacks.onSelect(index);
+      }
+    });
+    const actions=document.createElement('span');
+    actions.className='slot-actions';
+    const hide=document.createElement('button');
+    hide.textContent='Hide';
+    hide.className='hide-btn'+(slot.hidden?' active':'');
+    hide.addEventListener('click',e=>{e.stopPropagation();slotCallbacks.onToggleHide(slot);renderSlotsMobile(state,container,slotCallbacks,objectCallbacks,stepId);});
+    const del=document.createElement('button');
+    del.textContent='X';
+    del.className='action-btn';
+    del.addEventListener('click',e=>{e.stopPropagation();slotCallbacks.onDelete(slot.id);renderSlotsMobile(state,container,slotCallbacks,objectCallbacks,stepId);});
+    actions.appendChild(hide);actions.appendChild(del);sum.appendChild(actions);
+    det.appendChild(sum);
+    const body=document.createElement('div');
+    slot.objects.forEach((obj,objIndex)=>{
+      const card=document.createElement('div');
+      card.className='obj-card'+(objIndex===slot.selectedObjectIndex?' selected':'');
+      const title=document.createElement('div');
+      title.textContent=obj.name;
+      title.addEventListener('click',()=>{state.currentSlotIndex=index;objectCallbacks.onSelectObject(objIndex);});
+      const delBtn=document.createElement('button');
+      delBtn.textContent='Delete';
+      delBtn.className='action-btn';
+      delBtn.addEventListener('click',()=>{state.currentSlotIndex=index;objectCallbacks.onDelete(objIndex);renderSlotsMobile(state,container,slotCallbacks,objectCallbacks,stepId);});
+      const matList=document.createElement('div');
+      matList.className='material-list';
+      obj.materials.forEach((mat,matIndex)=>{
+        const btn=document.createElement('button');
+        const img=document.createElement('img');
+        const url=mat.previews?.[0]?.subRes?.small||mat.previews?.[0]?.url;
+        img.src=url||'';img.alt=mat.name;btn.appendChild(img);
+        btn.addEventListener('click',e=>{e.stopPropagation();state.currentSlotIndex=index;objectCallbacks.onSelectMaterial(objIndex,matIndex);renderSlotsMobile(state,container,slotCallbacks,objectCallbacks,stepId);});
+        if(objIndex===slot.selectedObjectIndex && matIndex===obj.selectedMaterial){btn.classList.add('selected');}
+        matList.appendChild(btn);
+      });
+      card.appendChild(title);card.appendChild(delBtn);card.appendChild(matList);body.appendChild(card);
+    });
+    det.appendChild(body);
+    container.appendChild(det);
+  });
+}

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,93 @@
+:root {
+  --color-Brand-Main: #4356f2;
+  --color-Gray-10: #e3e5e8;
+  --color-Gray-20: #c6cad2;
+  --color-Gray-70: #3f485a;
+  --color-Borders-Main: #dbdbdb;
+  --color-Text-Main: #3f485a;
+  --color-White: #fff;
+}
+
+body,html{margin:0;padding:0;height:100%;overflow:hidden;font-family:Inter,sans-serif;color:var(--color-Text-Main);}
+#container{display:flex;height:100%;}
+#slotsPanel,#objectsPanel{width:20%;background:var(--color-Gray-10);overflow-y:auto;padding:10px;}
+#slotsPanel{border-right:1px solid var(--color-Borders-Main);}
+#stepControls{display:flex;justify-content:center;align-items:center;gap:8px;margin-bottom:10px;}
+#objectsPanel{border-left:1px solid var(--color-Borders-Main);}
+#viewer{flex:1;position:relative;}
+canvas{display:block;}
+#bottomBtns{position:absolute;bottom:10px;left:50%;transform:translateX(-50%);}
+#bottomBtns button{margin:0 5px;}
+#transformBtns{position:absolute;top:10px;left:50%;transform:translateX(-50%);}
+#transformBtns button{margin:0 5px;}
+#coordsPanel{position:absolute;top:10px;right:10px;display:none;flex-direction:column;gap:5px;}
+#coordsPanel input{width:60px;text-align:center;background:var(--color-White);border:1px solid var(--color-Borders-Main);border-radius:4px;padding:4px;color:var(--color-Text-Main);}
+#coordsPanel input::-webkit-outer-spin-button,#coordsPanel input::-webkit-inner-spin-button{-webkit-appearance:none;margin:0;}
+#coordsPanel input[type=number]{-moz-appearance:textfield;}
+#objectActions{display:flex;gap:5px;margin-bottom:10px;}
+#canEmptyRow{display:flex;align-items:center;gap:5px;margin-bottom:10px;}
+#objectModal{position:fixed;top:10%;left:50%;transform:translateX(-50%);display:none;z-index:10;}
+#objectModal .modal-box{background:var(--color-White);border:1px solid var(--color-Borders-Main);width:60vw;max-height:80vh;padding:20px;overflow:auto;position:relative;}
+#modalList{display:grid;grid-template-columns:repeat(auto-fill,minmax(220px,1fr));gap:16px;max-height:60vh;overflow:auto;}
+#objectModal .modal-card{display:flex;flex-direction:column;gap:8px;cursor:pointer;}
+#objectModal .modal-card .thumb{position:relative;width:100%;padding-top:70%;border-radius:6px;overflow:hidden;background:var(--color-White);}
+#objectModal .modal-card .thumb img{position:absolute;top:0;left:0;width:100%;height:100%;object-fit:contain;}
+#objectModal .modal-card .overlay{position:absolute;inset:0;pointer-events:none;background:rgba(0,0,0,0.06);}
+#objectModal .modal-card .overlay::after{content:'';position:absolute;inset:0;opacity:0;transition:opacity .2s;background:linear-gradient(180deg,rgba(0,0,0,0.1) 65.38%,rgba(2,2,2,0.6) 100%);}
+#objectModal .modal-card:hover .overlay::after{opacity:1;}
+#objectModal .modal-card .thumb p{position:absolute;bottom:5px;left:5px;color:#fff;font-weight:bold;font-size:16px;max-width:70%;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;opacity:0;transition:opacity .2s;}
+#objectModal .modal-card:hover .thumb p{opacity:1;}
+#objectModal .modal-card .info{display:flex;justify-content:space-between;gap:8px;padding:0 4px;font-size:12px;}
+#objectModal .modal-card .info .owner{display:flex;align-items:center;gap:6px;flex:1;min-width:0;}
+#objectModal .modal-card .info .avatar{display:flex;align-items:center;justify-content:center;width:24px;height:24px;border-radius:50%;overflow:hidden;background:#ddd;flex-shrink:0;font-size:12px;font-weight:bold;color:#555;}
+#objectModal .modal-card .info .owner p{font-weight:600;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
+#objectModal .modal-card .info .counts{display:flex;gap:8px;flex-shrink:0;align-items:center;}
+#objectModal .modal-card .info .counts svg{width:16px;height:16px;fill:#777;}
+#objectModal .modal-card .info .counts p{margin-left:2px;font-size:11px;color:#777;}
+#objectModal .modal-card .info .counts .count{display:flex;align-items:center;}
+#objectModal .pagination{display:flex;justify-content:center;margin-top:10px;}
+#closeModal{display:block;margin:10px auto 0;}
+
+#stepsModal{position:fixed;top:10%;left:50%;transform:translateX(-50%);display:none;z-index:10;}
+#stepsModal .modal-box{background:var(--color-White);border:1px solid var(--color-Borders-Main);padding:20px;width:40vw;max-height:70vh;overflow:auto;}
+#stepsList{display:flex;flex-direction:column;gap:10px;margin-bottom:10px;}
+.step-row{display:flex;flex-direction:column;gap:4px;border:1px solid var(--color-Borders-Main);padding:8px;border-radius:4px;}
+.step-row .slot-checks{display:flex;flex-wrap:wrap;gap:6px;}
+.step-row .step-header{display:flex;align-items:center;gap:8px;margin-bottom:4px;}
+#closeSteps{display:block;margin:10px auto 0;}
+.obj-card{border:1px solid var(--color-Borders-Main);padding:5px;margin-bottom:5px;border-radius:4px;}
+.obj-card.selected{background:var(--color-Gray-20);}
+.material-list{display:flex;flex-wrap:wrap;}
+.material-list button{border:none;background:none;padding:0;margin:2px;cursor:pointer;}
+.material-list button.selected{outline:2px solid var(--color-Brand-Main);}
+.material-list img{width:40px;height:40px;object-fit:cover;border-radius:2px;}
+button{background:var(--color-Gray-10);border:1px solid var(--color-Borders-Main);border-radius:4px;padding:4px 8px;color:var(--color-Text-Main);transition:background .2s,color .2s;}
+button:hover{background:var(--color-Brand-Main);color:var(--color-White);}
+button.active{background:var(--color-Brand-Main);color:var(--color-White);}
+#slots{list-style:none;padding:0;margin:0;}
+.slot{display:flex;align-items:center;justify-content:space-between;margin-bottom:5px;cursor:pointer;padding:2px 4px;border-radius:4px;width:100%;}
+.slot.selected{background:var(--color-Gray-20);}
+.slot-actions{display:flex;gap:5px;}
+.slot-actions button{margin-left:0;}
+.action-btn{background:var(--color-White);}
+.action-btn:hover,.action-btn:active{background:var(--color-Brand-Main);color:var(--color-White);}
+#addSlotBtn{display:block;width:100%;margin-bottom:10px;}
+#gridBtn{position:absolute;bottom:10px;right:10px;}
+#outlineBtn{position:absolute;bottom:10px;right:80px;}
+.hide-btn.active{background:var(--color-Gray-70);color:var(--color-White);}
+#loadingOverlay{position:fixed;inset:0;background:rgba(0,0,0,0.5);display:none;align-items:center;justify-content:center;z-index:20;}
+#loadingOverlay .loading-box{text-align:center;color:var(--color-White);}
+#loadingOverlay .progress{width:200px;height:8px;background:var(--color-Gray-20);margin-top:10px;border-radius:4px;overflow:hidden;}
+#progressBar{height:100%;width:0;background:var(--color-Brand-Main);}
+
+@media (max-width:768px){
+  #container{flex-direction:column;}
+  #viewer{flex:none;height:66vh;}
+  #slotsPanel{order:2;width:100%;height:34vh;border-right:none;border-top:1px solid var(--color-Borders-Main);}
+  #objectsPanel{display:none;}
+  #slots{padding:10px;}
+  .slot-mobile summary{display:flex;justify-content:space-between;align-items:center;padding:4px;cursor:pointer;}
+  .slot-mobile summary::-webkit-details-marker{display:none;}
+  .slot-mobile{border-bottom:1px solid var(--color-Borders-Main);}
+  .slot-mobile .obj-card{margin:5px 0;}
+}

--- a/viewer/index.html
+++ b/viewer/index.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Viewer</title>
+  <link rel="stylesheet" href="viewer.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet" />
+  <script type="importmap">
+  {
+    "imports": {
+      "three": "https://unpkg.com/three@0.165.0/build/three.module.js",
+      "OrbitControls": "https://unpkg.com/three@0.165.0/examples/jsm/controls/OrbitControls.js",
+      "GLTFLoader": "https://unpkg.com/three@0.165.0/examples/jsm/loaders/GLTFLoader.js",
+      "RGBELoader": "https://unpkg.com/three@0.165.0/examples/jsm/loaders/RGBELoader.js",
+      "GLTFExporter": "https://unpkg.com/three@0.165.0/examples/jsm/exporters/GLTFExporter.js",
+      "USDZExporter": "https://unpkg.com/three@0.165.0/examples/jsm/exporters/USDZExporter.js",
+      "BufferGeometryUtils": "https://unpkg.com/three@0.165.0/examples/jsm/utils/BufferGeometryUtils.js",
+      "EffectComposer": "https://unpkg.com/three@0.165.0/examples/jsm/postprocessing/EffectComposer.js",
+      "RenderPass": "https://unpkg.com/three@0.165.0/examples/jsm/postprocessing/RenderPass.js",
+      "OutlinePass": "https://unpkg.com/three@0.165.0/examples/jsm/postprocessing/OutlinePass.js",
+      "ShaderPass": "https://unpkg.com/three@0.165.0/examples/jsm/postprocessing/ShaderPass.js",
+      "FXAAShader": "https://unpkg.com/three@0.165.0/examples/jsm/shaders/FXAAShader.js",
+      "OutputPass": "https://unpkg.com/three@0.165.0/examples/jsm/postprocessing/OutputPass.js"
+    }
+  }
+  </script>
+</head>
+<body>
+  <div id="viewerWrapper">
+    <div id="viewerCanvas">
+      <div id="bottomButtons">
+        <button id="arBtn">AR</button>
+        <button id="importBtn">Import JSON</button>
+        <input type="file" id="importInput" accept="application/json" style="display:none" />
+      </div>
+    </div>
+    <div id="slotPanel">
+      <div id="stepControls">
+        <button id="prevStep">Prev</button>
+        <span id="stepName"></span>
+        <button id="nextStep">Next</button>
+      </div>
+      <div id="slotsContainer"></div>
+    </div>
+  </div>
+  <div id="loadingOverlay">
+    <div class="loading-box">
+      <p>Loading</p>
+      <div class="progress"><div id="progressBar"></div></div>
+    </div>
+  </div>
+  <script type="module" src="./js/viewer-main.js"></script>
+</body>
+</html>

--- a/viewer/js/viewer-api.js
+++ b/viewer/js/viewer-api.js
@@ -1,0 +1,14 @@
+export async function fetchObjectDetails(uuid){
+  try{
+    const res = await fetch('https://api.vizbl.us/obj/Fetch',{ 
+      method:'POST',
+      headers:{'Content-Type':'application/json'},
+      body:JSON.stringify({uuid})
+    });
+    if(!res.ok) return null;
+    return await res.json();
+  }catch(e){
+    console.error('fetchObjectDetails',e);
+    return null;
+  }
+}

--- a/viewer/js/viewer-main.js
+++ b/viewer/js/viewer-main.js
@@ -1,0 +1,384 @@
+import * as THREE from 'three';
+import { OrbitControls } from 'OrbitControls';
+import { GLTFLoader } from 'GLTFLoader';
+import { RGBELoader } from 'RGBELoader';
+import { GLTFExporter } from 'GLTFExporter';
+import { USDZExporter } from 'USDZExporter';
+import { EffectComposer } from 'EffectComposer';
+import { RenderPass } from 'RenderPass';
+import { OutlinePass } from 'OutlinePass';
+import { ShaderPass } from 'ShaderPass';
+import { FXAAShader } from 'FXAAShader';
+import { OutputPass } from 'OutputPass';
+import { ViewerState } from './viewer-state.js';
+import { renderSlots } from './viewer-ui.js';
+import { fetchObjectDetails } from './viewer-api.js';
+
+const container = document.getElementById('viewerCanvas');
+const slotPanel = document.getElementById('slotPanel');
+const slotsContainer = document.getElementById('slotsContainer');
+const importBtn = document.getElementById('importBtn');
+const importInput = document.getElementById('importInput');
+const arBtn = document.getElementById('arBtn');
+const stepNameEl = document.getElementById('stepName');
+const prevStepBtn = document.getElementById('prevStep');
+const nextStepBtn = document.getElementById('nextStep');
+const stepControls = document.getElementById('stepControls');
+
+const scene = new THREE.Scene();
+const camera = new THREE.PerspectiveCamera(60, 1, 0.1, 1000);
+const renderer = new THREE.WebGLRenderer({ antialias: true });
+renderer.outputEncoding = THREE.sRGBEncoding;
+renderer.toneMapping = THREE.LinearToneMapping;
+renderer.physicallyCorrectLights = true;
+renderer.setClearColor(0xffffff, 1);
+container.appendChild(renderer.domElement);
+const controls = new OrbitControls(camera, renderer.domElement);
+camera.position.set(0, 1, 3);
+controls.update();
+
+const pmrem = new THREE.PMREMGenerator(renderer);
+new RGBELoader().load(
+  'https://raw.githubusercontent.com/donmccurdy/three-gltf-viewer/master/assets/environment/neutral.hdr',
+  (hdr) => {
+    const envMap = pmrem.fromEquirectangular(hdr).texture;
+    scene.environment = envMap;
+    scene.background = envMap;
+    hdr.dispose();
+    pmrem.dispose();
+  }
+);
+
+const ambient = new THREE.AmbientLight(0xffffff, 0.3);
+scene.add(ambient);
+const dirLight = new THREE.DirectionalLight(0xffffff, 2.5);
+dirLight.position.set(5, 10, 7.5);
+scene.add(dirLight);
+
+// postprocessing for hover outline
+const composer = new EffectComposer(renderer);
+const renderPass = new RenderPass(scene, camera);
+composer.addPass(renderPass);
+const outlinePass = new OutlinePass(new THREE.Vector2(1, 1), scene, camera);
+outlinePass.edgeStrength = 3;
+outlinePass.visibleEdgeColor.set(0x008efa);
+outlinePass.hiddenEdgeColor.set(0xffffff);
+// ensure the outline blends normally over the scene
+outlinePass.overlayMaterial.blending = THREE.NormalBlending;
+outlinePass.overlayMaterial.transparent = true;
+composer.addPass(outlinePass);
+const outputPass = new OutputPass();
+composer.addPass(outputPass);
+const effectFXAA = new ShaderPass(FXAAShader);
+effectFXAA.uniforms['resolution'].value.set(1 / container.clientWidth, 1 / container.clientHeight);
+composer.addPass(effectFXAA);
+
+function resize() {
+  const w = container.clientWidth;
+  const h = container.clientHeight;
+  renderer.setSize(w, h);
+  composer.setSize(w, h);
+  outlinePass.setSize(w, h);
+  effectFXAA.uniforms['resolution'].value.set(1 / w, 1 / h);
+  camera.aspect = w / h;
+  camera.updateProjectionMatrix();
+}
+window.addEventListener('resize', resize);
+resize();
+
+function animate() {
+  requestAnimationFrame(animate);
+  composer.render();
+}
+animate();
+
+const state = new ViewerState();
+const loader = new GLTFLoader();
+const raycaster = new THREE.Raycaster();
+const pointer = new THREE.Vector2();
+let pointerDown = null;
+let pointerMoved = false;
+let hovered = null;
+
+function renderUI(){
+  stepNameEl.textContent = state.currentStep?.name || '';
+  stepControls.style.display = state.steps.length>1 ? 'flex' : 'none';
+  renderSlots(slotsContainer, state, selectObject);
+}
+
+function arrayBufferToBase64(buffer) {
+  let binary = '';
+  const bytes = new Uint8Array(buffer);
+  const len = bytes.byteLength;
+  for (let i = 0; i < len; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary);
+}
+
+function buildExportScene(srcScene) {
+  const group = new THREE.Group();
+
+  srcScene.traverse((child) => {
+    if (child.isMesh && child.visible) {
+      const clonedMat = Array.isArray(child.material)
+        ? child.material.map((m) => {
+            const cm = m.clone();
+            cm.side = THREE.FrontSide;
+            return cm;
+          })
+        : (() => {
+            const cm = child.material.clone();
+            cm.side = THREE.FrontSide;
+            return cm;
+          })();
+
+      const clone = child.clone();
+      clone.material = clonedMat;
+      clone.geometry = child.geometry.clone();
+      child.updateWorldMatrix(true, false);
+      clone.applyMatrix4(child.matrixWorld);
+      group.add(clone);
+    }
+  });
+
+  if (!group.children.length) return new THREE.Scene();
+
+  const box = new THREE.Box3().setFromObject(group);
+  const center = box.getCenter(new THREE.Vector3());
+  group.position.sub(center);
+
+  const exportScene = new THREE.Scene();
+  exportScene.add(group);
+  return exportScene;
+}
+
+function showLoading(r) {
+  const overlay = document.getElementById('loadingOverlay');
+  const bar = document.getElementById('progressBar');
+  overlay.style.display = 'flex';
+  bar.style.width = Math.floor(r * 100) + '%';
+}
+function hideLoading() {
+  document.getElementById('loadingOverlay').style.display = 'none';
+  document.getElementById('progressBar').style.width = '0';
+}
+
+async function loadMesh(obj) {
+  if (obj.mesh) return obj.mesh;
+  const mat = obj.materials[obj.selectedMaterial || 0];
+  const url = mat?.native?.glbUrl;
+  if (!url) return null;
+  return await new Promise((resolve) => {
+    loader.load(
+      url,
+      (gltf) => {
+        obj.mesh = gltf.scene;
+        resolve(obj.mesh);
+      },
+      (evt) => {
+        if (evt.total) showLoading(evt.loaded / evt.total);
+      },
+      (err) => {
+        console.error(err);
+        hideLoading();
+        resolve(null);
+      }
+    );
+  });
+}
+
+async function selectObject(slotIdx, objIdx, matIdx) {
+  const slot = state.slots[slotIdx];
+  if (slot.currentMesh) {
+    scene.remove(slot.currentMesh);
+    slot.currentMesh = null;
+  }
+  slot.selectedIndex = objIdx;
+  if (objIdx === -1) {
+    renderUI();
+    return;
+  }
+  const obj = slot.objects[objIdx];
+  if (typeof matIdx === 'number') obj.selectedMaterial = matIdx;
+  obj.mesh = null; // force reload for new material
+  const mesh = await loadMesh(obj);
+  hideLoading();
+  if (!mesh) {
+    renderUI();
+    return;
+  }
+  const inst = mesh.clone();
+  inst.position.fromArray(obj.transform.position);
+  inst.rotation.set(
+    ...obj.transform.rotation.map((r) => THREE.MathUtils.degToRad(r))
+  );
+  inst.scale.fromArray(obj.transform.scale);
+  inst.userData.slotIdx = slotIdx;
+  inst.userData.objIdx = objIdx;
+  slot.currentMesh = inst;
+  scene.add(inst);
+  renderUI();
+}
+
+function setHovered(obj) {
+  if (hovered === obj) return;
+  hovered = obj;
+  outlinePass.selectedObjects = obj ? [obj] : [];
+}
+
+async function loadAll(){
+  state.slots.forEach(s=>{
+    if(s.currentMesh){
+      scene.remove(s.currentMesh);
+      s.currentMesh=null;
+    }
+  });
+  for(const slot of state.slots){
+    if(slot.selectedIndex>=0){
+      const obj = slot.objects[slot.selectedIndex];
+      const mesh = await loadMesh(obj);
+      if(mesh){
+        const inst = mesh.clone();
+        inst.position.fromArray(obj.transform.position);
+        inst.rotation.set(...obj.transform.rotation.map(r=>THREE.MathUtils.degToRad(r)));
+        inst.scale.fromArray(obj.transform.scale);
+        inst.userData.slotIdx = state.slots.indexOf(slot);
+        inst.userData.objIdx = slot.selectedIndex;
+        slot.currentMesh = inst;
+        scene.add(inst);
+      }
+    }
+  }
+  hideLoading();
+  renderUI();
+}
+
+function handleHover(event) {
+  const rect = renderer.domElement.getBoundingClientRect();
+  pointer.x = ((event.clientX - rect.left) / rect.width) * 2 - 1;
+  pointer.y = -((event.clientY - rect.top) / rect.height) * 2 + 1;
+  raycaster.setFromCamera(pointer, camera);
+  const objs = state.slots.map((s) => s.currentMesh).filter(Boolean);
+  const intersect = raycaster.intersectObjects(objs, true)[0];
+  let obj = intersect ? intersect.object : null;
+  while (obj && obj.userData.slotIdx === undefined) obj = obj.parent;
+  setHovered(obj);
+}
+
+function handleSceneClick(event) {
+  const rect = renderer.domElement.getBoundingClientRect();
+  pointer.x = ((event.clientX - rect.left) / rect.width) * 2 - 1;
+  pointer.y = -((event.clientY - rect.top) / rect.height) * 2 + 1;
+  raycaster.setFromCamera(pointer, camera);
+  const objs = state.slots.map((s) => s.currentMesh).filter(Boolean);
+  const intersect = raycaster.intersectObjects(objs, true)[0];
+  if (!intersect) return;
+  let obj = intersect.object;
+  while (obj && obj.userData.slotIdx === undefined) obj = obj.parent;
+  if (!obj) return;
+  const slotIdx = obj.userData.slotIdx;
+  const objIdx = obj.userData.objIdx;
+  const slot = state.slots[slotIdx];
+  slot.selectedIndex = objIdx;
+  slot.open = true;
+    renderUI();
+    const slotEl = slotsContainer.children[state.slots.indexOf(slot)];
+  if (slotEl) {
+    slotEl.open = true;
+    slotEl.scrollIntoView({ block: 'nearest' });
+  }
+}
+
+renderer.domElement.addEventListener('pointerdown', (e) => {
+  if (e.button !== 0) return;
+  pointerDown = { x: e.clientX, y: e.clientY };
+  pointerMoved = false;
+});
+
+renderer.domElement.addEventListener('pointermove', (e) => {
+  handleHover(e);
+  if (!pointerDown) return;
+  if (Math.abs(e.clientX - pointerDown.x) > 5 || Math.abs(e.clientY - pointerDown.y) > 5) {
+    pointerMoved = true;
+  }
+});
+
+renderer.domElement.addEventListener('pointerup', (e) => {
+  if (e.button !== 0) return;
+  if (!pointerMoved) handleSceneClick(e);
+  handleHover(e);
+  pointerDown = null;
+});
+
+renderer.domElement.addEventListener('pointerleave', () => {
+  setHovered(null);
+});
+
+async function handleImport(file) {
+  const text = await file.text();
+  const data = JSON.parse(text);
+  // remove previous meshes from scene
+  state.slots.forEach((s) => {
+    if (s.currentMesh) {
+      scene.remove(s.currentMesh);
+      s.currentMesh = null;
+    }
+  });
+
+  await state.loadConfig(data, fetchObjectDetails);
+  await loadAll();
+}
+
+importBtn.addEventListener('click', () => importInput.click());
+importInput.addEventListener('change', (e) => {
+  const file = e.target.files[0];
+  if (file) handleImport(file);
+});
+
+prevStepBtn.addEventListener('click',()=>{
+  state.currentStepIndex = (state.currentStepIndex - 1 + state.steps.length) % state.steps.length;
+  renderUI();
+});
+nextStepBtn.addEventListener('click',()=>{
+  state.currentStepIndex = (state.currentStepIndex + 1) % state.steps.length;
+  renderUI();
+});
+
+arBtn.addEventListener('click', async () => {
+  const exportScene = buildExportScene(scene);
+  if (!exportScene.children.length) return;
+
+  if (isAndroid()) {
+    const exporter = new GLTFExporter();
+    const arrayBuffer = await exporter.parseAsync(exportScene, { binary: true });
+    const base64 = arrayBufferToBase64(arrayBuffer);
+    const dataUrl = `data:model/gltf-binary;base64,${base64}`;
+    const intent =
+      `intent://arvr.google.com/scene-viewer/1.0?file=${encodeURIComponent(dataUrl)}#Intent;scheme=https;package=com.google.android.googlequicksearchbox;action=android.intent.action.VIEW;end;`;
+    const win = window.open(intent, '_blank');
+    if (win) win.focus();
+  } else if (isIOS()) {
+    const exporter = new USDZExporter();
+    const arrayBuffer = await exporter.parseAsync(exportScene);
+    const blob = new Blob([arrayBuffer], { type: 'model/vnd.usdz+zip' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.rel = 'ar';
+    a.href = url;
+    a.setAttribute('download', 'scene.usdz');
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    setTimeout(() => URL.revokeObjectURL(url), 1000);
+  } else {
+    alert('AR not supported');
+  }
+});
+
+function isAndroid() {
+  return /android/i.test(navigator.userAgent);
+}
+function isIOS() {
+  return /iPad|iPhone|iPod/.test(navigator.userAgent);
+}

--- a/viewer/js/viewer-state.js
+++ b/viewer/js/viewer-state.js
@@ -1,0 +1,52 @@
+export class ViewerState{
+  constructor(){
+    this.slots=[];
+    this.steps=[];
+    this.currentStepIndex=0;
+  }
+
+  async loadConfig(data, fetchDetails){
+    this.slots=[];
+    this.steps = Object.entries(data.steps || {}).map(([id,s])=>({id,name:s.name,index:s.index||0}));
+    if(!this.steps.length){
+      const def={id:crypto.randomUUID(),name:'Step 1',index:0};
+      this.steps=[def];
+    }
+    this.steps.sort((a,b)=>a.index-b.index);
+    this.currentStepIndex=0;
+    const defaultStepId = this.steps[0].id;
+    for(const [id, slotData] of Object.entries(data.slots || {})){
+      const slot={
+        id,
+        name: slotData.name,
+        canBeEmpty: slotData.canBeEmpty,
+        objects: [],
+        selectedIndex: slotData.canBeEmpty ? -1 : 0,
+        open:false,
+        currentMesh:null,
+        stepId: slotData.step || defaultStepId
+      };
+      for(const obj of slotData.objects || []){
+        const details = await fetchDetails(obj.uuid);
+        if(!details) continue;
+        slot.objects.push({
+          uuid: obj.uuid,
+          name: details.name,
+          materials: details.materials || [],
+          selectedMaterial:0,
+          transform: {
+            position: obj.position || [0,0,0],
+            rotation: obj.rotation || [0,0,0],
+            scale: obj.scale || [1,1,1]
+          },
+          mesh: null
+        });
+      }
+      this.slots.push(slot);
+    }
+  }
+
+  get currentStep(){
+    return this.steps[this.currentStepIndex];
+  }
+}

--- a/viewer/js/viewer-ui.js
+++ b/viewer/js/viewer-ui.js
@@ -1,0 +1,55 @@
+export function renderSlots(container, state, onSelect){
+  container.innerHTML='';
+  const stepId = state.currentStep?.id;
+  state.slots.filter(s=>s.stepId===stepId).forEach((slot)=>{
+    const sIdx = state.slots.indexOf(slot);
+    const det=document.createElement('details');
+    det.open = slot.open;
+    det.addEventListener('toggle',()=>{slot.open = det.open;});
+    const sum=document.createElement('summary');
+    sum.textContent=slot.name;
+    det.appendChild(sum);
+    const list=document.createElement('div');
+    list.className='object-list';
+    if(slot.canBeEmpty){
+      const none=document.createElement('div');
+      none.className='object-item';
+      if(slot.selectedIndex===-1) none.classList.add('selected');
+      const noneThumb=document.createElement('div');
+      noneThumb.className='none-thumb';
+      noneThumb.textContent='✕';
+      none.appendChild(noneThumb);
+      const label=document.createElement('div');
+      label.className='label';
+      label.textContent='None';
+      none.appendChild(label);
+      none.addEventListener('click',()=>onSelect(sIdx,-1,0));
+      list.appendChild(none);
+    }
+    slot.objects.forEach((obj,oIdx)=>{
+      const objLabel=document.createElement('div');
+      objLabel.className='object-label';
+      objLabel.textContent=obj.name;
+      list.appendChild(objLabel);
+      obj.materials.forEach((mat,mIdx)=>{
+        const item=document.createElement('div');
+        item.className='object-item';
+        if(slot.selectedIndex===oIdx && obj.selectedMaterial===mIdx) item.classList.add('selected');
+        const img=document.createElement('img');
+        const prev=mat.previews?.[0];
+        img.src=prev?.subRes?.small||prev?.url||'';
+        img.alt=mat.name;
+        item.appendChild(img);
+        const label=document.createElement('div');
+        label.className='label';
+        label.textContent=mat.name;
+        item.appendChild(label);
+        const slotIndex = state.slots.indexOf(slot);
+        item.addEventListener('click',()=>onSelect(slotIndex,oIdx,mIdx));
+        list.appendChild(item);
+      });
+    });
+    det.appendChild(list);
+    container.appendChild(det);
+  });
+}

--- a/viewer/viewer.css
+++ b/viewer/viewer.css
@@ -1,0 +1,150 @@
+:root {
+  --color-Brand-Main: #4356f2;
+  --color-Gray-10: #e3e5e8;
+  --color-Gray-20: #c6cad2;
+  --color-Gray-70: #3f485a;
+  --color-Borders-Main: #dbdbdb;
+  --color-Text-Main: #3f485a;
+  --color-White: #fff;
+}
+
+html,body {
+  margin:0;
+  height:100%;
+  overflow:hidden;
+  font-family:Inter,sans-serif;
+  color:var(--color-Text-Main);
+}
+
+#viewerWrapper {
+  display:flex;
+  height:100%;
+}
+
+#viewerCanvas {
+  flex:2;
+  position:relative;
+}
+
+#slotPanel {
+  flex:1;
+  overflow-y:auto;
+  background:var(--color-Gray-10);
+  padding:10px;
+}
+
+#stepControls{
+  display:flex;
+  justify-content:center;
+  align-items:center;
+  gap:8px;
+  margin-bottom:10px;
+}
+
+@media(max-width:768px){
+  #viewerWrapper {flex-direction:column;}
+  #viewerCanvas {height:66.666%;flex:none;}
+  #slotPanel {height:33.333%;width:100%;flex:none;}
+}
+
+canvas {display:block;}
+
+#bottomButtons {
+  position:absolute;
+  bottom:10px;
+  left:50%;
+  transform:translateX(-50%);
+  display:flex;
+  gap:10px;
+}
+
+button {
+  background:var(--color-Gray-10);
+  border:1px solid var(--color-Borders-Main);
+  border-radius:4px;
+  padding:4px 8px;
+  color:var(--color-Text-Main);
+  transition:background .2s,color .2s;
+}
+button:hover {
+  background:var(--color-Brand-Main);
+  color:var(--color-White);
+}
+
+/* slot list */
+#slotPanel details {
+  margin-bottom:8px;
+}
+#slotPanel summary {
+  cursor:pointer;
+  padding:4px 8px;
+  background:var(--color-Gray-20);
+  border-radius:4px;
+}
+.object-list {
+  display:flex;
+  flex-wrap:wrap;
+  gap:8px;
+  padding:8px 0;
+}
+.object-item {
+  width:70px;
+  text-align:center;
+  cursor:pointer;
+}
+.object-item img, .object-item .none-thumb {
+  width:70px;
+  height:70px;
+  object-fit:contain;
+  background:var(--color-White);
+  border:1px solid var(--color-Borders-Main);
+  border-radius:4px;
+}
+.object-item .label {
+  margin-top:4px;
+  font-size:12px;
+  white-space:nowrap;
+  overflow:hidden;
+  text-overflow:ellipsis;
+}
+.object-item.selected img, .object-item.selected .none-thumb {
+  outline:2px solid var(--color-Brand-Main);
+}
+.none-thumb {
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  font-size:24px;
+  color:var(--color-Gray-70);
+}
+
+.object-label{
+  width:100%;
+  font-weight:600;
+  margin-top:8px;
+}
+
+/* loading overlay */
+#loadingOverlay {
+  position:fixed;
+  inset:0;
+  background:rgba(0,0,0,0.5);
+  display:none;
+  align-items:center;
+  justify-content:center;
+  z-index:100;
+  color:var(--color-White);
+}
+#loadingOverlay .progress {
+  width:200px;
+  height:8px;
+  background:var(--color-Gray-20);
+  margin-top:10px;
+  border-radius:4px;
+  overflow:hidden;
+}
+#progressBar {
+  height:100%;
+  width:0;
+  background:var(--color-Brand-Main);
+}


### PR DESCRIPTION
## Summary
- show all slots in the standalone viewer and load every selected object at once
- group configurator slots by step with prev/next controls and allow deleting steps
- restrict slot lists to the active step across desktop and mobile UIs
- reintroduce step navigation in the viewer so its UI cycles through steps while the scene shows all slots

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895693faecc8322bc8546c552325c84