### PR TITLE
feat: auto-load viewer config and stabilize AR export

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,1 +1,141 @@
-
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>3D Configurator</title>
+  <link rel="stylesheet" href="styles.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet" />
+  <script type="importmap">
+  {
+    "imports": {
+      "three": "https://unpkg.com/three@0.165.0/build/three.module.js",
+      "OrbitControls": "https://unpkg.com/three@0.165.0/examples/jsm/controls/OrbitControls.js",
+      "GLTFLoader": "https://unpkg.com/three@0.165.0/examples/jsm/loaders/GLTFLoader.js",
+      "RGBELoader": "https://unpkg.com/three@0.165.0/examples/jsm/loaders/RGBELoader.js",
+      "TransformControls": "https://unpkg.com/three@0.165.0/examples/jsm/controls/TransformControls.js",
+      "EffectComposer": "https://unpkg.com/three@0.165.0/examples/jsm/postprocessing/EffectComposer.js",
+      "RenderPass": "https://unpkg.com/three@0.165.0/examples/jsm/postprocessing/RenderPass.js",
+      "OutlinePass": "https://unpkg.com/three@0.165.0/examples/jsm/postprocessing/OutlinePass.js",
+      "ShaderPass": "https://unpkg.com/three@0.165.0/examples/jsm/postprocessing/ShaderPass.js",
+      "FXAAShader": "./js/FXAAShader.js",
+      "OutputPass": "https://unpkg.com/three@0.165.0/examples/jsm/postprocessing/OutputPass.js"
+    }
+  }
+  </script>
+</head>
+<body>
+  <div id="container">
+    <div id="slotsPanel">
+      <div id="variantControls">
+        <select id="variantSelect"></select>
+        <button id="addVariant" class="action-btn">+</button>
+        <button id="delVariant" class="action-btn">-</button>
+        <button id="renVariant" class="action-btn">Rename</button>
+      </div>
+      <div id="stepControls">
+        <button id="prevStep">Prev</button>
+        <span id="stepName"></span>
+        <button id="nextStep">Next</button>
+        <button id="delStep" class="action-btn">Delete step</button>
+      </div>
+      <button id="addSlotBtn" class="action-btn">Add slot</button>
+      <ul id="slots"></ul>
+      <div id="envRow">
+        <button id="envBtn" class="action-btn">Environment</button>
+        <button id="lockBtn" class="action-btn active">Lock</button>
+      </div>
+    </div>
+    <div id="viewer">
+      <div id="transformBtns">
+        <button id="moveBtn">Move</button>
+        <button id="rotateBtn">Rotate</button>
+        <button id="scaleBtn">Scale</button>
+        <button id="noneBtn">None</button>
+      </div>
+      <div id="coordsPanel">
+        <input type="number" id="coordX" step="0.01" />
+        <input type="number" id="coordY" step="0.01" />
+        <input type="number" id="coordZ" step="0.01" />
+      </div>
+      <div id="bottomBtns">
+        <button id="exportBtn">Export JSON</button>
+        <button id="importBtn">Import JSON</button>
+        <button id="stepsBtn">Steps</button>
+        <button id="viewToggle" class="action-btn">Preview view</button>
+        <button id="viewBtn" class="action-btn" style="display:none">Setting view</button>
+        <input type="file" id="importInput" accept="application/json" style="display:none" />
+      </div>
+      <button id="outlineBtn" class="action-btn">Outline</button>
+      <button id="gridBtn" class="action-btn">Grid</button>
+    </div>
+    <div id="objectsPanel">
+      <div id="objectActions">
+        <button id="addObjectBtn" class="action-btn">Add object</button>
+        <button id="inheritBtn" class="action-btn">Inherit first</button>
+      </div>
+      <div id="slotOptions">
+        <label><input type="checkbox" id="canBeEmpty"> Can be empty</label>
+        <label><input type="checkbox" id="textButtons"> Button text</label>
+        <button id="slotSettings" class="action-btn">Settings</button>
+      </div>
+      <div id="objects"></div>
+    </div>
+  </div>
+  <div id="versionLabel">ver 0.02</div>
+  <div id="objectModal">
+    <div class="modal-box">
+      <div id="modalList"></div>
+      <div class="pagination">
+        <button id="prevPage">Prev</button>
+        <span id="pageInfo"></span>
+        <button id="nextPage">Next</button>
+      </div>
+    </div>
+    <button id="closeModal">Close</button>
+  </div>
+  <div id="stepsModal">
+    <div class="modal-box">
+      <div id="stepsList"></div>
+      <button id="addStep">Add step</button>
+      <button id="saveSteps">Save</button>
+    </div>
+    <button id="closeSteps">Close</button>
+  </div>
+  <div id="envModal">
+    <div class="modal-box">
+      <label>Environment UUID <input type="text" id="envUuid"></label>
+      <button id="loadEnv" class="action-btn">Load</button>
+      <button id="removeEnv" class="action-btn">Remove</button>
+    </div>
+    <button id="closeEnv">Close</button>
+  </div>
+  <div id="varModal">
+    <div class="modal-box">
+      <div id="varList"></div>
+      <button id="saveVar" class="action-btn">Save</button>
+    </div>
+    <button id="closeVar">Close</button>
+  </div>
+  <div id="viewModal">
+    <div class="modal-box">
+      <label><input type="checkbox" id="viewEnabled"> Activate view point</label>
+      <label>Left angle <input type="number" id="viewLeft"/></label>
+      <label>Right angle <input type="number" id="viewRight"/></label>
+      <label>Down angle <input type="number" id="viewDown"/></label>
+      <label>Up angle <input type="number" id="viewUp"/></label>
+      <label>Max distance <input type="number" id="viewDist"/></label>
+      <label><input type="checkbox" id="viewMove"> Allow movement</label>
+      <button id="saveView" class="action-btn">Save</button>
+    </div>
+    <button id="closeView">Close</button>
+  </div>
+  <div id="loadingOverlay">
+    <div class="loading-box">
+      <p>Loading</p>
+      <div class="progress"><div id="progressBar"></div></div>
+    </div>
+  </div>
+  <script type="module" src="./js/main.js"></script>
+</body>
+</html>

--- a/js/FXAAShader.js
+++ b/js/FXAAShader.js
@@ -1,0 +1,292 @@
+import { Vector2 } from 'three';
+
+/**
+ * FXAA algorithm from NVIDIA, C# implementation by Jasper Flick, GLSL port by Dave Hoskins.
+ *
+ * References:
+ * - {@link http://developer.download.nvidia.com/assets/gamedev/files/sdk/11/FXAA_WhitePaper.pdf}.
+ * - {@link https://catlikecoding.com/unity/tutorials/advanced-rendering/fxaa/}.
+ *
+ * @constant
+ * @type {ShaderMaterial~Shader}
+ */
+const FXAAShader = {
+
+    name: 'FXAAShader',
+
+    uniforms: {
+
+        'tDiffuse': { value: null },
+        'resolution': { value: new Vector2( 1 / 1024, 1 / 512 ) }
+
+    },
+
+    vertexShader: /* glsl */`
+
+        varying vec2 vUv;
+
+        void main() {
+
+            vUv = uv;
+            gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+
+        }`,
+
+    fragmentShader: /* glsl */`
+
+        uniform sampler2D tDiffuse;
+        uniform vec2 resolution;
+        varying vec2 vUv;
+
+        #define EDGE_STEP_COUNT 6
+        #define EDGE_GUESS 8.0
+        #define EDGE_STEPS 1.0, 1.5, 2.0, 2.0, 2.0, 4.0
+        const float edgeSteps[EDGE_STEP_COUNT] = float[EDGE_STEP_COUNT]( EDGE_STEPS );
+
+        float _ContrastThreshold = 0.0312;
+        float _RelativeThreshold = 0.063;
+        float _SubpixelBlending = 1.0;
+
+        vec4 Sample( sampler2D  tex2D, vec2 uv ) {
+
+            return texture( tex2D, uv );
+
+        }
+
+        float SampleLuminance( sampler2D tex2D, vec2 uv ) {
+
+            return dot( Sample( tex2D, uv ).rgb, vec3( 0.3, 0.59, 0.11 ) );
+
+        }
+
+        float SampleLuminance( sampler2D tex2D, vec2 texSize, vec2 uv, float uOffset, float vOffset ) {
+
+            uv += texSize * vec2(uOffset, vOffset);
+            return SampleLuminance(tex2D, uv);
+
+        }
+
+        struct LuminanceData {
+
+            float m, n, e, s, w;
+            float ne, nw, se, sw;
+            float highest, lowest, contrast;
+
+        };
+
+        LuminanceData SampleLuminanceNeighborhood( sampler2D tex2D, vec2 texSize, vec2 uv ) {
+
+            LuminanceData l;
+            l.m = SampleLuminance( tex2D, uv );
+            l.n = SampleLuminance( tex2D, texSize, uv,  0.0,  1.0 );
+            l.e = SampleLuminance( tex2D, texSize, uv,  1.0,  0.0 );
+            l.s = SampleLuminance( tex2D, texSize, uv,  0.0, -1.0 );
+            l.w = SampleLuminance( tex2D, texSize, uv, -1.0,  0.0 );
+
+            l.ne = SampleLuminance( tex2D, texSize, uv,  1.0,  1.0 );
+            l.nw = SampleLuminance( tex2D, texSize, uv, -1.0,  1.0 );
+            l.se = SampleLuminance( tex2D, texSize, uv,  1.0, -1.0 );
+            l.sw = SampleLuminance( tex2D, texSize, uv, -1.0, -1.0 );
+
+            l.highest = max( max( max( max( l.n, l.e ), l.s ), l.w ), l.m );
+            l.lowest = min( min( min( min( l.n, l.e ), l.s ), l.w ), l.m );
+            l.contrast = l.highest - l.lowest;
+            return l;
+
+        }
+
+        bool ShouldSkipPixel( LuminanceData l ) {
+
+            float threshold = max( _ContrastThreshold, _RelativeThreshold * l.highest );
+            return l.contrast < threshold;
+
+        }
+
+        float DeterminePixelBlendFactor( LuminanceData l ) {
+
+            float f = 2.0 * ( l.n + l.e + l.s + l.w );
+            f += l.ne + l.nw + l.se + l.sw;
+            f *= 1.0 / 12.0;
+            f = abs( f - l.m );
+            f = clamp( f / l.contrast, 0.0, 1.0 );
+
+            float blendFactor = smoothstep( 0.0, 1.0, f );
+            return blendFactor * blendFactor * _SubpixelBlending;
+
+        }
+
+        struct EdgeData {
+
+            bool isHorizontal;
+            float pixelStep;
+            float oppositeLuminance, gradient;
+
+        };
+
+        EdgeData DetermineEdge( vec2 texSize, LuminanceData l ) {
+
+            EdgeData e;
+            float horizontal =
+                abs( l.n + l.s - 2.0 * l.m ) * 2.0 +
+                abs( l.ne + l.se - 2.0 * l.e ) +
+                abs( l.nw + l.sw - 2.0 * l.w );
+            float vertical =
+                abs( l.e + l.w - 2.0 * l.m ) * 2.0 +
+                abs( l.ne + l.nw - 2.0 * l.n ) +
+                abs( l.se + l.sw - 2.0 * l.s );
+            e.isHorizontal = horizontal >= vertical;
+
+            float pLuminance = e.isHorizontal ? l.n : l.e;
+            float nLuminance = e.isHorizontal ? l.s : l.w;
+            float pGradient = abs( pLuminance - l.m );
+            float nGradient = abs( nLuminance - l.m );
+
+            e.pixelStep = e.isHorizontal ? texSize.y : texSize.x;
+
+            if (pGradient < nGradient) {
+
+                e.pixelStep = -e.pixelStep;
+                e.oppositeLuminance = nLuminance;
+                e.gradient = nGradient;
+
+            } else {
+
+                e.oppositeLuminance = pLuminance;
+                e.gradient = pGradient;
+
+            }
+
+            return e;
+
+        }
+
+        float DetermineEdgeBlendFactor( sampler2D  tex2D, vec2 texSize, LuminanceData l, EdgeData e, vec2 uv ) {
+
+            vec2 uvEdge = uv;
+            vec2 edgeStep;
+            if (e.isHorizontal) {
+
+                uvEdge.y += e.pixelStep * 0.5;
+                edgeStep = vec2( texSize.x, 0.0 );
+
+            } else {
+
+                uvEdge.x += e.pixelStep * 0.5;
+                edgeStep = vec2( 0.0, texSize.y );
+
+            }
+
+            float edgeLuminance = ( l.m + e.oppositeLuminance ) * 0.5;
+            float gradientThreshold = e.gradient * 0.25;
+
+            vec2 puv = uvEdge + edgeStep * edgeSteps[0];
+            float pLuminanceDelta = SampleLuminance( tex2D, puv ) - edgeLuminance;
+            bool pAtEnd = abs( pLuminanceDelta ) >= gradientThreshold;
+
+            for ( int i = 1; i < EDGE_STEP_COUNT && !pAtEnd; i++ ) {
+
+                puv += edgeStep * edgeSteps[i];
+                pLuminanceDelta = SampleLuminance( tex2D, puv ) - edgeLuminance;
+                pAtEnd = abs( pLuminanceDelta ) >= gradientThreshold;
+
+            }
+
+            if ( !pAtEnd ) {
+
+                puv += edgeStep * EDGE_GUESS;
+
+            }
+
+            vec2 nuv = uvEdge - edgeStep * edgeSteps[0];
+            float nLuminanceDelta = SampleLuminance( tex2D, nuv ) - edgeLuminance;
+            bool nAtEnd = abs( nLuminanceDelta ) >= gradientThreshold;
+
+            for ( int i = 1; i < EDGE_STEP_COUNT && !nAtEnd; i++ ) {
+
+                nuv -= edgeStep * edgeSteps[i];
+                nLuminanceDelta = SampleLuminance( tex2D, nuv ) - edgeLuminance;
+                nAtEnd = abs( nLuminanceDelta ) >= gradientThreshold;
+
+            }
+
+            if ( !nAtEnd ) {
+
+                nuv -= edgeStep * EDGE_GUESS;
+
+            }
+
+            float pDistance, nDistance;
+            if ( e.isHorizontal ) {
+
+                pDistance = puv.x - uv.x;
+                nDistance = uv.x - nuv.x;
+
+            } else {
+
+                pDistance = puv.y - uv.y;
+                nDistance = uv.y - nuv.y;
+
+            }
+
+            float shortestDistance;
+            bool deltaSign;
+            if ( pDistance <= nDistance ) {
+
+                shortestDistance = pDistance;
+                deltaSign = pLuminanceDelta >= 0.0;
+
+            } else {
+
+                shortestDistance = nDistance;
+                deltaSign = nLuminanceDelta >= 0.0;
+
+            }
+
+            if ( deltaSign == ( l.m - edgeLuminance >= 0.0 ) ) {
+
+                return 0.0;
+
+            }
+
+            return 0.5 - shortestDistance / ( pDistance + nDistance );
+
+        }
+
+        vec4 ApplyFXAA( sampler2D  tex2D, vec2 texSize, vec2 uv ) {
+
+            LuminanceData luminance = SampleLuminanceNeighborhood( tex2D, texSize, uv );
+            if ( ShouldSkipPixel( luminance ) ) {
+
+                return Sample( tex2D, uv );
+
+            }
+
+            float pixelBlend = DeterminePixelBlendFactor( luminance );
+            EdgeData edge = DetermineEdge( texSize, luminance );
+            float edgeBlend = DetermineEdgeBlendFactor( tex2D, texSize, luminance, edge, uv );
+            float finalBlend = max( pixelBlend, edgeBlend );
+
+            if (edge.isHorizontal) {
+
+                uv.y += edge.pixelStep * finalBlend;
+
+            } else {
+
+                uv.x += edge.pixelStep * finalBlend;
+
+            }
+
+            return Sample( tex2D, uv );
+
+        }
+
+        void main() {
+
+            gl_FragColor = ApplyFXAA( tDiffuse, resolution.xy, vUv );
+
+        }`
+
+};
+
+export { FXAAShader };
+

--- a/js/api.js
+++ b/js/api.js
@@ -1,0 +1,25 @@
+export async function fetchObjects(page = 1) {
+  try {
+    const res = await fetch(`https://api.vizbl.us/obj/GetPublic?page=${page}`);
+    if (!res.ok) throw new Error('Network response was not ok');
+    return await res.json();
+  } catch (err) {
+    console.error('API error', err);
+    return { objs: [], pages_count: 0 };
+  }
+}
+
+export async function fetchObjectDetails(uuid) {
+  try {
+    const res = await fetch('https://api.vizbl.us/obj/Fetch', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ uuid })
+    });
+    if (!res.ok) throw new Error('Network response was not ok');
+    return await res.json();
+  } catch (err) {
+    console.error('API error', err);
+    return null;
+  }
+}

--- a/js/main.js
+++ b/js/main.js
@@ -1,0 +1,955 @@
+import * as THREE from 'three';
+import { OrbitControls } from 'OrbitControls';
+import { GLTFLoader } from 'GLTFLoader';
+import { RGBELoader } from 'RGBELoader';
+import { TransformControls } from 'TransformControls';
+import { EffectComposer } from 'EffectComposer';
+import { RenderPass } from 'RenderPass';
+import { OutlinePass } from 'OutlinePass';
+import { ShaderPass } from 'ShaderPass';
+import { FXAAShader } from 'FXAAShader';
+import { OutputPass } from 'OutputPass';
+import { ConfiguratorState } from './state.js';
+import { renderSlots, renderObjects, renderSlotsMobile } from './ui.js';
+import { openObjectModal, openStepsModal } from './modal.js';
+import { fetchObjectDetails } from './api.js';
+
+const state = new ConfiguratorState();
+
+const slotListEl = document.getElementById('slots');
+const variantSelect = document.getElementById('variantSelect');
+const addVariantBtn = document.getElementById('addVariant');
+const delVariantBtn = document.getElementById('delVariant');
+const renVariantBtn = document.getElementById('renVariant');
+const addSlotBtn = document.getElementById('addSlotBtn');
+const prevStepBtn = document.getElementById('prevStep');
+const nextStepBtn = document.getElementById('nextStep');
+const stepNameEl = document.getElementById('stepName');
+const delStepBtn = document.getElementById('delStep');
+const stepControls = document.getElementById('stepControls');
+const addObjectBtn = document.getElementById('addObjectBtn');
+const inheritBtn = document.getElementById('inheritBtn');
+const objectsContainer = document.getElementById('objects');
+const objectActionsRow = document.getElementById('objectActions');
+const slotOptionsRow = document.getElementById('slotOptions');
+const canBeEmptyChk = document.getElementById('canBeEmpty');
+const textButtonsChk = document.getElementById('textButtons');
+const slotSettingsBtn = document.getElementById('slotSettings');
+const exportBtn = document.getElementById('exportBtn');
+const importBtn = document.getElementById('importBtn');
+const importInput = document.getElementById('importInput');
+const stepsBtn = document.getElementById('stepsBtn');
+const viewBtn = document.getElementById('viewBtn');
+const viewToggleBtn = document.getElementById('viewToggle');
+const stepsModal = document.getElementById('stepsModal');
+const modalEl = document.getElementById('objectModal');
+const moveBtn = document.getElementById('moveBtn');
+const rotateBtn = document.getElementById('rotateBtn');
+const scaleBtn = document.getElementById('scaleBtn');
+const noneBtn = document.getElementById('noneBtn');
+const gridBtn = document.getElementById('gridBtn');
+const outlineBtn = document.getElementById('outlineBtn');
+const coordsPanel = document.getElementById('coordsPanel');
+const coordX = document.getElementById('coordX');
+const coordY = document.getElementById('coordY');
+const coordZ = document.getElementById('coordZ');
+const loadingOverlay = document.getElementById('loadingOverlay');
+const progressBar = document.getElementById('progressBar');
+const envBtn = document.getElementById('envBtn');
+const lockBtn = document.getElementById('lockBtn');
+const envModal = document.getElementById('envModal');
+const envUuidInput = document.getElementById('envUuid');
+const loadEnvBtn = document.getElementById('loadEnv');
+const removeEnvBtn = document.getElementById('removeEnv');
+const closeEnvBtn = document.getElementById('closeEnv');
+const varModal = document.getElementById('varModal');
+const varList = document.getElementById('varList');
+const saveVarBtn = document.getElementById('saveVar');
+const closeVarBtn = document.getElementById('closeVar');
+const viewModal = document.getElementById('viewModal');
+const viewLeft = document.getElementById('viewLeft');
+const viewRight = document.getElementById('viewRight');
+const viewDown = document.getElementById('viewDown');
+const viewUp = document.getElementById('viewUp');
+const viewDist = document.getElementById('viewDist');
+const viewMove = document.getElementById('viewMove');
+const viewEnabled = document.getElementById('viewEnabled');
+const saveViewBtn = document.getElementById('saveView');
+const closeViewBtn = document.getElementById('closeView');
+outlineBtn.classList.add('active');
+
+// THREE.js setup
+const viewer = document.getElementById('viewer');
+const renderer = new THREE.WebGLRenderer({ antialias: true });
+renderer.setPixelRatio(window.devicePixelRatio);
+renderer.setSize(viewer.clientWidth, viewer.clientHeight);
+renderer.outputEncoding = THREE.sRGBEncoding;
+renderer.toneMapping = THREE.LinearToneMapping;
+renderer.physicallyCorrectLights = true;
+renderer.setClearColor(0xffffff, 1);
+viewer.appendChild(renderer.domElement);
+const scene = new THREE.Scene();
+const pmrem = new THREE.PMREMGenerator(renderer);
+new RGBELoader().load(
+  'https://vizbl.com/hdr/neutral.hdr',
+  (hdr) => {
+    const envMap = pmrem.fromEquirectangular(hdr).texture;
+    scene.environment = envMap;
+    scene.background = envMap;
+    hdr.dispose();
+    pmrem.dispose();
+  }
+);
+const camera = new THREE.PerspectiveCamera(60, viewer.clientWidth / viewer.clientHeight, 0.1, 1000);
+camera.position.set(0, 1, 3);
+const orbit = new OrbitControls(camera, renderer.domElement);
+const loader = new GLTFLoader();
+const transform = new TransformControls(camera, renderer.domElement);
+transform.addEventListener('dragging-changed', e => { orbit.enabled = !e.value; });
+const gizmoScene = new THREE.Scene();
+gizmoScene.add(transform);
+
+const defaultCamPos = camera.position.clone();
+const defaultTarget = orbit.target.clone();
+let viewPreview = false;
+
+// postprocessing for hover outline
+const composer = new EffectComposer(renderer);
+composer.setSize(viewer.clientWidth, viewer.clientHeight);
+const renderPass = new RenderPass(scene, camera);
+composer.addPass(renderPass);
+const outlinePass = new OutlinePass(
+  new THREE.Vector2(viewer.clientWidth, viewer.clientHeight),
+  scene,
+  camera
+);
+outlinePass.edgeStrength = 2;
+outlinePass.edgeThickness = 12;
+outlinePass.visibleEdgeColor.set(0x888888);
+outlinePass.hiddenEdgeColor.set(0xffffff);
+// ensure the outline blends normally over the scene
+outlinePass.overlayMaterial.blending = THREE.NormalBlending;
+outlinePass.overlayMaterial.transparent = true;
+composer.addPass(outlinePass);
+const outputPass = new OutputPass();
+composer.addPass(outputPass);
+const effectFXAA = new ShaderPass(FXAAShader);
+effectFXAA.uniforms['resolution'].value.set(1 / viewer.clientWidth, 1 / viewer.clientHeight);
+composer.addPass(effectFXAA);
+
+// lighting similar to gltf-viewer defaults
+const ambientLight = new THREE.AmbientLight(0xffffff, 0.3);
+scene.add(ambientLight);
+const dirLight = new THREE.DirectionalLight(0xffffff, 2.5);
+dirLight.position.set(5, 10, 7.5);
+scene.add(dirLight);
+
+const grid = new THREE.GridHelper(10, 10);
+grid.visible = false;
+scene.add(grid);
+
+const viewPivot = new THREE.Mesh(new THREE.SphereGeometry(0.05), new THREE.MeshBasicMaterial({color:0xff0000}));
+viewPivot.userData.view = true;
+scene.add(viewPivot);
+viewPivot.position.fromArray(state.viewPoint.position);
+viewPivot.rotation.set(
+  THREE.MathUtils.degToRad(state.viewPoint.rotation[0]),
+  THREE.MathUtils.degToRad(state.viewPoint.rotation[1]),
+  THREE.MathUtils.degToRad(state.viewPoint.rotation[2])
+);
+
+function applyViewPreview(){
+  const vp = state.viewPoint;
+  orbit.target.set(vp.position[0], vp.position[1], vp.position[2]);
+  const offset = new THREE.Vector3(0,1,3);
+  const euler = new THREE.Euler(
+    THREE.MathUtils.degToRad(vp.rotation[0]),
+    THREE.MathUtils.degToRad(vp.rotation[1]),
+    THREE.MathUtils.degToRad(vp.rotation[2])
+  );
+  offset.applyEuler(euler);
+  camera.position.set(
+    vp.position[0] + offset.x,
+    vp.position[1] + offset.y,
+    vp.position[2] + offset.z
+  );
+  const sph = new THREE.Spherical().setFromVector3(offset);
+  const basePolar = sph.phi;
+  const baseAzimuth = sph.theta;
+  if(vp.up>0) {
+    orbit.minPolarAngle = Math.max(0, basePolar - THREE.MathUtils.degToRad(vp.up));
+  } else {
+    orbit.minPolarAngle = 0;
+  }
+  if(vp.down>0) {
+    orbit.maxPolarAngle = Math.min(Math.PI, basePolar + THREE.MathUtils.degToRad(vp.down));
+  } else {
+    orbit.maxPolarAngle = Math.PI;
+  }
+  if(vp.left>0) {
+    orbit.minAzimuthAngle = baseAzimuth - THREE.MathUtils.degToRad(vp.left);
+  } else {
+    orbit.minAzimuthAngle = -Infinity;
+  }
+  if(vp.right>0) {
+    orbit.maxAzimuthAngle = baseAzimuth + THREE.MathUtils.degToRad(vp.right);
+  } else {
+    orbit.maxAzimuthAngle = Infinity;
+  }
+  orbit.maxDistance = vp.maxDistance>0 ? vp.maxDistance : Infinity;
+  orbit.enablePan = vp.allowMovement;
+  orbit.update();
+}
+
+function resetViewPreview(){
+  orbit.target.copy(defaultTarget);
+  camera.position.copy(defaultCamPos);
+  orbit.minPolarAngle=0;
+  orbit.maxPolarAngle=Math.PI;
+  orbit.minAzimuthAngle=-Infinity;
+  orbit.maxAzimuthAngle=Infinity;
+  orbit.maxDistance=Infinity;
+  orbit.enablePan=true;
+  orbit.update();
+}
+
+const raycaster = new THREE.Raycaster();
+const pointer = new THREE.Vector2();
+let pointerDown = null;
+let pointerMoved = false;
+let hovered = null;
+
+function isMobile(){
+  return window.innerWidth <= 768;
+}
+
+function handleResize(){
+  renderer.setSize(viewer.clientWidth, viewer.clientHeight);
+  composer.setSize(viewer.clientWidth, viewer.clientHeight);
+  effectFXAA.uniforms['resolution'].value.set(1 / viewer.clientWidth, 1 / viewer.clientHeight);
+  camera.aspect = viewer.clientWidth / viewer.clientHeight;
+  camera.updateProjectionMatrix();
+  renderUI();
+}
+
+window.addEventListener('resize', handleResize);
+
+const meshes = {};
+let envMesh = null;
+let envLocked = true;
+let transformMode = null;
+
+const axisNames = ['x','y','z'];
+
+function updatePanels(){
+  if(state.currentSlotIndex===-1){
+    objectActionsRow.style.display='none';
+    slotOptionsRow.style.display='none';
+    viewBtn.style.display='inline-block';
+    objectsContainer.innerHTML='';
+  }else{
+    objectActionsRow.style.display='flex';
+    slotOptionsRow.style.display='flex';
+    viewBtn.style.display='none';
+  }
+}
+
+function updateCoordInputs(){
+  if (transformMode === null || !transform.object) {
+    coordsPanel.style.display = 'none';
+    return;
+  }
+  coordsPanel.style.display = 'flex';
+  if (transformMode === 'translate') {
+    coordX.value = transform.object.position.x.toFixed(2);
+    coordY.value = transform.object.position.y.toFixed(2);
+    coordZ.value = transform.object.position.z.toFixed(2);
+  } else if (transformMode === 'rotate') {
+    coordX.value = THREE.MathUtils.radToDeg(transform.object.rotation.x).toFixed(1);
+    coordY.value = THREE.MathUtils.radToDeg(transform.object.rotation.y).toFixed(1);
+    coordZ.value = THREE.MathUtils.radToDeg(transform.object.rotation.z).toFixed(1);
+  } else if (transformMode === 'scale') {
+    coordX.value = transform.object.scale.x.toFixed(2);
+    coordY.value = transform.object.scale.y.toFixed(2);
+    coordZ.value = transform.object.scale.z.toFixed(2);
+  }
+}
+
+[coordX, coordY, coordZ].forEach((input, idx) => {
+  input.addEventListener('focus', () => input.select());
+  input.addEventListener('change', () => {
+    if (!transform.object) return;
+    const val = parseFloat(input.value);
+    if (isNaN(val)) return;
+    if(transform.object === viewPivot){
+      if(transformMode === 'translate'){
+        viewPivot.position[axisNames[idx]] = val;
+        state.viewPoint.position[idx] = val;
+      }else if(transformMode === 'rotate'){
+        const rad = THREE.MathUtils.degToRad(val);
+        viewPivot.rotation[axisNames[idx]] = rad;
+        state.viewPoint.rotation[idx] = val;
+      }
+    } else {
+      const obj = transform.object.userData.stateObj || transform.object.userData.envObj;
+      if (transformMode === 'translate') {
+        transform.object.position[axisNames[idx]] = val;
+        obj.transform.position[idx] = val;
+      } else if (transformMode === 'rotate') {
+        const rad = THREE.MathUtils.degToRad(val);
+        transform.object.rotation[axisNames[idx]] = rad;
+        obj.transform.rotation[idx] = val;
+      } else if (transformMode === 'scale') {
+        transform.object.scale[axisNames[idx]] = val;
+        obj.transform.scale[idx] = val;
+      }
+    }
+    updateCoordInputs();
+  });
+});
+
+function showLoading(){
+  loadingOverlay.style.display='flex';
+  progressBar.style.width='0%';
+}
+
+function updateLoading(p){
+  progressBar.style.width = `${Math.round(p*100)}%`;
+}
+
+function hideLoading(){
+  loadingOverlay.style.display='none';
+}
+
+function loadEnvironment(env){
+  if(envMesh){
+    if(transform.object===envMesh) transform.detach();
+    scene.remove(envMesh);
+    envMesh=null;
+  }
+  if(!env) { setHovered(hovered); updateCoordInputs(); return; }
+  const mat = env.materials[env.selectedMaterial];
+  const url = mat?.native?.glbUrl;
+  if(!url) return;
+  const loadId = crypto.randomUUID();
+  env._loadId = loadId;
+  showLoading();
+  loader.load(url, gltf=>{
+    if(env._loadId!==loadId){hideLoading();return;}
+    envMesh=gltf.scene;
+    envMesh.traverse(ch=>{
+      if(ch.isMesh){
+        ch.castShadow=false; ch.receiveShadow=false;
+        const m=ch.material;
+        ch.material=new THREE.MeshBasicMaterial({
+          map:m.map, aoMap:m.aoMap, aoMapIntensity:m.aoMapIntensity,
+          color:m.color?.clone(), transparent:m.transparent, opacity:m.opacity, side:m.side
+        });
+      }
+    });
+    envMesh.position.fromArray(env.transform.position);
+    envMesh.rotation.set(
+      THREE.MathUtils.degToRad(env.transform.rotation[0]),
+      THREE.MathUtils.degToRad(env.transform.rotation[1]),
+      THREE.MathUtils.degToRad(env.transform.rotation[2])
+    );
+    envMesh.scale.fromArray(env.transform.scale);
+    envMesh.userData.envObj = env;
+    scene.add(envMesh);
+    setHovered(hovered && hovered.userData.envObj ? null : hovered);
+    if(transformMode!==null && state.currentSlotIndex===-1 && !envLocked) transform.attach(envMesh); else transform.detach();
+    hideLoading();
+  },xhr=>{ if(xhr.total) updateLoading(xhr.loaded/xhr.total); },err=>{console.error(err);hideLoading();});
+}
+
+function reloadScene(){
+  Object.values(meshes).forEach(m=>{ if(transform.object===m) transform.detach(); scene.remove(m);});
+  Object.keys(meshes).forEach(k=>delete meshes[k]);
+  if(envMesh){
+    if(transform.object===envMesh) transform.detach();
+    scene.remove(envMesh); envMesh=null;
+  }
+  if(state.environment) loadEnvironment(state.environment);
+  state.slots.forEach((slot,idx)=>loadSlot(slot, idx===state.currentSlotIndex));
+  viewPivot.position.fromArray(state.viewPoint.position);
+  viewPivot.rotation.set(
+    THREE.MathUtils.degToRad(state.viewPoint.rotation[0]),
+    THREE.MathUtils.degToRad(state.viewPoint.rotation[1]),
+    THREE.MathUtils.degToRad(state.viewPoint.rotation[2])
+  );
+  viewPivot.visible = !state.viewPoint.hidden;
+  if(viewPreview) applyViewPreview();
+}
+
+function renderVariants(){
+  variantSelect.innerHTML='';
+  state.variants.forEach((v,i)=>{
+    const opt=document.createElement('option');
+    opt.value=i; opt.textContent=v.name;
+    variantSelect.appendChild(opt);
+  });
+  variantSelect.value=state.currentVariantIndex;
+}
+
+function animate() {
+  requestAnimationFrame(animate);
+  composer.render();
+  renderer.autoClear = false;
+  renderer.render(gizmoScene, camera);
+  renderer.autoClear = true;
+}
+animate();
+
+// track transform changes for the currently attached object
+transform.addEventListener('objectChange', () => {
+  if(transform.object===viewPivot){
+    state.viewPoint.position = [viewPivot.position.x, viewPivot.position.y, viewPivot.position.z];
+    state.viewPoint.rotation = [
+      THREE.MathUtils.radToDeg(viewPivot.rotation.x),
+      THREE.MathUtils.radToDeg(viewPivot.rotation.y),
+      THREE.MathUtils.radToDeg(viewPivot.rotation.z)
+    ];
+    if(viewPreview) applyViewPreview();
+  } else {
+    const obj = transform.object?.userData?.stateObj || transform.object?.userData?.envObj;
+    if (!obj) return;
+    obj.transform.position = [transform.object.position.x, transform.object.position.y, transform.object.position.z];
+    obj.transform.rotation = [
+      THREE.MathUtils.radToDeg(transform.object.rotation.x),
+      THREE.MathUtils.radToDeg(transform.object.rotation.y),
+      THREE.MathUtils.radToDeg(transform.object.rotation.z)
+    ];
+    obj.transform.scale = [transform.object.scale.x, transform.object.scale.y, transform.object.scale.z];
+  }
+  updateCoordInputs();
+});
+
+function loadObject(slot, obj, attach = false) {
+  const mat = obj.materials[obj.selectedMaterial];
+  const url = mat?.native?.glbUrl;
+  if (!url) return;
+  const loadId = crypto.randomUUID();
+  slot._loadId = loadId;
+  showLoading();
+  loader.load(
+    url,
+    gltf => {
+      if (slot._loadId !== loadId) { hideLoading(); return; }
+      const mesh = gltf.scene;
+      mesh.position.fromArray(obj.transform.position);
+      mesh.rotation.set(
+        THREE.MathUtils.degToRad(obj.transform.rotation[0]),
+        THREE.MathUtils.degToRad(obj.transform.rotation[1]),
+        THREE.MathUtils.degToRad(obj.transform.rotation[2])
+      );
+      mesh.scale.fromArray(obj.transform.scale);
+      mesh.userData.stateObj = obj;
+      mesh.userData.slotId = slot.id;
+      scene.add(mesh);
+      meshes[slot.id] = mesh;
+      if (attach && transformMode !== null) attachTransformControls(mesh, obj);
+      hideLoading();
+    },
+    xhr => {
+      if (xhr.total) updateLoading(xhr.loaded / xhr.total);
+    },
+    err => {
+      console.error('Load error', err);
+      hideLoading();
+    }
+  );
+}
+
+function loadSlot(slot, attach = false) {
+  const existing = meshes[slot.id];
+  if (existing) {
+    if (transform.object === existing) transform.detach();
+    scene.remove(existing);
+    delete meshes[slot.id];
+  }
+  if (slot.hidden || slot.selectedObjectIndex === -1) {
+    updateCoordInputs();
+    return;
+  }
+  const obj = slot.objects[slot.selectedObjectIndex];
+  loadObject(slot, obj, attach && transformMode !== null);
+}
+
+function attachTransformControls(mesh, obj) {
+  if (transformMode === null) return;
+  mesh.userData.stateObj = obj;
+  transform.attach(mesh);
+  transform.enabled = true;
+  updateCoordInputs();
+}
+
+function activateSlot(slot) {
+  if (transformMode === null) {
+    transform.detach();
+  }
+  if (!slot) {
+    if (transformMode !== null) {
+      transform.attach(viewPivot);
+      transform.enabled = true;
+    } else {
+      transform.detach();
+    }
+    updateCoordInputs();
+    return;
+  }
+  if (slot.selectedObjectIndex === -1 || slot.hidden) {
+    transform.detach();
+    updateCoordInputs();
+    return;
+  }
+  const mesh = meshes[slot.id];
+  if (mesh) {
+    if (transformMode !== null) transform.attach(mesh);
+  } else {
+    loadSlot(slot, transformMode !== null);
+  }
+  transform.enabled = transformMode !== null;
+  updateCoordInputs();
+}
+
+function setHovered(obj) {
+  if (hovered === obj) return;
+  hovered = obj;
+  outlinePass.selectedObjects = obj ? [obj] : [];
+}
+
+function handleHover(event) {
+  const rect = renderer.domElement.getBoundingClientRect();
+  pointer.x = ((event.clientX - rect.left) / rect.width) * 2 - 1;
+  pointer.y = -((event.clientY - rect.top) / rect.height) * 2 + 1;
+  raycaster.setFromCamera(pointer, camera);
+  const objs = [...Object.values(meshes), viewPivot];
+  if(envMesh && !envLocked) objs.push(envMesh);
+  const intersect = raycaster.intersectObjects(objs, true)[0];
+  let obj = intersect ? intersect.object : null;
+  while (obj && !obj.userData.slotId && !obj.userData.envObj) obj = obj.parent;
+  setHovered(obj && obj.userData.envObj ? null : obj);
+}
+
+function handleSceneClick(event) {
+  const rect = renderer.domElement.getBoundingClientRect();
+  pointer.x = ((event.clientX - rect.left) / rect.width) * 2 - 1;
+  pointer.y = -((event.clientY - rect.top) / rect.height) * 2 + 1;
+  raycaster.setFromCamera(pointer, camera);
+  const objs2 = [...Object.values(meshes), viewPivot];
+  if(envMesh && !envLocked) objs2.push(envMesh);
+  const intersect = raycaster.intersectObjects(objs2, true)[0];
+  if (!intersect) return;
+  let obj = intersect.object;
+  if(obj === viewPivot){
+    state.currentSlotIndex = -1;
+    renderUI();
+    if(transformMode!==null) transform.attach(viewPivot); else transform.detach();
+    transform.enabled = transformMode !== null;
+    updateCoordInputs();
+    return;
+  }
+  while (obj && !obj.userData.slotId && !obj.userData.envObj) obj = obj.parent;
+  if (!obj) return;
+  if(obj.userData.envObj){
+    if(envLocked) return;
+    state.currentSlotIndex = -1;
+    renderUI();
+    if(transformMode!==null) transform.attach(envMesh); else transform.detach();
+    transform.enabled = transformMode !== null;
+    updateCoordInputs();
+    return;
+  }
+  const slotIndex = state.slots.findIndex(s => s.id === obj.userData.slotId);
+  if (slotIndex === -1) return;
+  const slot = state.slots[slotIndex];
+  const objIdx = slot.objects.indexOf(obj.userData.stateObj);
+  if (objIdx !== -1) slot.selectedObjectIndex = objIdx;
+  slotCallbacks.onSelect(slotIndex);
+}
+
+// UI callbacks
+function selectSlot(index){
+  if(index==='view'){
+    state.currentSlotIndex = -1;
+    renderUI();
+    activateSlot(null);
+    return;
+  }
+  if(typeof index!=='number' || !state.slots[index]) return;
+  state.currentSlotIndex = index;
+  const stepIdx = state.steps.findIndex(st=>st.id===state.slots[index]?.stepId);
+  if(stepIdx!==-1) state.currentStepIndex = stepIdx;
+  renderUI();
+  activateSlot(state.currentSlot);
+  const el = slotListEl.children[state.slots.filter(s=>s.stepId===state.currentStep.id).indexOf(state.currentSlot)+1];
+  if (el) el.scrollIntoView({ block: 'nearest' });
+}
+
+const slotCallbacks = {
+  onSelect: selectSlot,
+  onDelete(id) {
+    const mesh = meshes[id];
+    if (mesh) {
+      if (transform.object === mesh) transform.detach();
+      scene.remove(mesh);
+      delete meshes[id];
+    }
+    state.removeSlot(id);
+    renderUI();
+    if(state.currentSlotIndex===-1) activateSlot(null); else activateSlot(state.currentSlot);
+  },
+  onToggleHide(slot) {
+    if(slot==='view'){
+      state.viewPoint.hidden = !state.viewPoint.hidden;
+      viewPivot.visible = !state.viewPoint.hidden;
+      renderUI();
+      return;
+    }
+    slot.hidden = !slot.hidden;
+    const mesh = meshes[slot.id];
+    if (slot.hidden) {
+      if (mesh) {
+        if (transform.object === mesh) transform.detach();
+        scene.remove(mesh);
+        delete meshes[slot.id];
+      }
+    } else {
+      loadSlot(slot, slot === state.currentSlot);
+    }
+    renderUI();
+  }
+};
+
+const objectCallbacks = {
+  onSelectObject(index) {
+    const slot = state.currentSlot;
+    slot.selectedObjectIndex = index;
+    renderUI();
+    loadSlot(slot, true);
+  },
+  onSelectMaterial(objIndex, matIndex) {
+    const slot = state.currentSlot;
+    slot.selectedObjectIndex = objIndex;
+    const obj = slot.objects[objIndex];
+    obj.selectedMaterial = matIndex;
+    renderUI();
+    loadSlot(slot, true);
+  },
+  onDelete(objIndex) {
+    const slot = state.currentSlot;
+    slot.objects.splice(objIndex, 1);
+    if (slot.selectedObjectIndex >= slot.objects.length) {
+      slot.selectedObjectIndex = slot.objects.length - 1;
+    }
+    renderUI();
+    loadSlot(slot, true);
+  }
+};
+
+addSlotBtn.addEventListener('click', () => {
+  const slot = state.addSlot();
+  renderUI();
+  canBeEmptyChk.checked = state.currentSlot?.canBeEmpty || false;
+  if(slot.selectedObjectIndex !== -1) loadSlot(slot, true);
+});
+
+addObjectBtn.addEventListener('click', () => {
+  if (!state.currentSlot) return;
+  openObjectModal(modalEl, {
+    async onSelect(objData) {
+      const details = await fetchObjectDetails(objData.uuid);
+      if (!details) return;
+      state.addObjectToCurrent(details);
+      renderUI();
+      loadSlot(state.currentSlot, true);
+    }
+  });
+});
+
+exportBtn.addEventListener('click', () => {
+  const json = state.exportJSON();
+  const blob = new Blob([json], { type: 'application/json' });
+  const a = document.createElement('a');
+  a.href = URL.createObjectURL(blob);
+  a.download = 'config.json';
+  a.click();
+  URL.revokeObjectURL(a.href);
+});
+
+importBtn.addEventListener('click', () => importInput && importInput.click());
+importInput && importInput.addEventListener('change', async e => {
+  const file = e.target.files[0];
+  if (!file) return;
+  try {
+    const text = await file.text();
+    const data = JSON.parse(text);
+    await handleImport(data);
+  } catch (err) {
+    console.error('Import failed', err);
+  }
+  if (importInput) importInput.value = '';
+});
+
+stepsBtn.addEventListener('click', () => {
+  openStepsModal(stepsModal, state, renderUI);
+});
+
+viewBtn.addEventListener('click', () => {
+  if (!viewEnabled || !viewLeft || !viewRight || !viewDown || !viewUp || !viewDist || !viewMove) return;
+  viewEnabled.checked = state.viewPoint.enabled;
+  viewLeft.value = state.viewPoint.left;
+  viewRight.value = state.viewPoint.right;
+  viewDown.value = state.viewPoint.down;
+  viewUp.value = state.viewPoint.up;
+  viewDist.value = state.viewPoint.maxDistance;
+  viewMove.checked = state.viewPoint.allowMovement;
+  viewModal.style.display = 'block';
+});
+saveViewBtn.addEventListener('click', () => {
+  if (!viewEnabled || !viewLeft || !viewRight || !viewDown || !viewUp || !viewDist || !viewMove) return;
+  state.viewPoint.enabled = viewEnabled.checked;
+  state.viewPoint.left = parseFloat(viewLeft.value) || 0;
+  state.viewPoint.right = parseFloat(viewRight.value) || 0;
+  state.viewPoint.down = parseFloat(viewDown.value) || 0;
+  state.viewPoint.up = parseFloat(viewUp.value) || 0;
+  state.viewPoint.maxDistance = parseFloat(viewDist.value) || 0;
+  state.viewPoint.allowMovement = viewMove.checked;
+  viewModal.style.display = 'none';
+  if (viewPreview) applyViewPreview();
+});
+closeViewBtn.addEventListener('click', ()=>{viewModal.style.display='none';});
+
+viewToggleBtn.addEventListener('click',()=>{
+  viewPreview = !viewPreview;
+  viewToggleBtn.classList.toggle('active', viewPreview);
+  if(viewPreview) applyViewPreview(); else resetViewPreview();
+});
+
+function changeStep(delta){
+  const len = state.steps.length;
+  state.currentStepIndex = (state.currentStepIndex + delta + len) % len;
+  const stepId = state.currentStep.id;
+  const idx = state.slots.findIndex(s=>s.stepId===stepId);
+  state.currentSlotIndex = idx;
+  renderUI();
+}
+
+prevStepBtn.addEventListener('click',()=>changeStep(-1));
+nextStepBtn.addEventListener('click',()=>changeStep(1));
+delStepBtn.addEventListener('click',()=>{
+  if(state.steps.length<=1) return;
+  const step = state.currentStep;
+  const idx = state.steps.indexOf(step);
+  state.steps.splice(idx,1);
+  state.slots.forEach(s=>{ if(s.stepId===step.id) s.stepId = state.steps[0].id; });
+  if(state.currentStepIndex>=state.steps.length) state.currentStepIndex=0;
+  renderUI();
+});
+
+variantSelect.addEventListener('change',()=>{
+  state.currentVariantIndex=parseInt(variantSelect.value); state.currentSlotIndex=-1; state.currentStepIndex=0;
+  renderUI();
+  reloadScene();
+});
+addVariantBtn.addEventListener('click',()=>{state.addVariant(); renderVariants(); renderUI(); reloadScene();});
+delVariantBtn.addEventListener('click',()=>{state.deleteCurrentVariant(); renderVariants(); renderUI(); reloadScene();});
+renVariantBtn.addEventListener('click',()=>{const name=prompt('Variant name',state.currentVariant.name); if(name){state.renameCurrentVariant(name); renderVariants();}});
+
+envBtn.addEventListener('click',()=>{envModal.style.display='block';});
+lockBtn.addEventListener('click',()=>{
+  envLocked = !envLocked;
+  lockBtn.classList.toggle('active', envLocked);
+  if(envLocked && transform.object===envMesh) transform.detach();
+  if(!envLocked && envMesh && state.currentSlotIndex===-1 && transformMode!==null) transform.attach(envMesh);
+  updateCoordInputs();
+});
+closeEnvBtn.addEventListener('click',()=>{envModal.style.display='none';});
+loadEnvBtn.addEventListener('click',async()=>{
+  const uuid=envUuidInput.value.trim(); if(!uuid) return;
+  const details=await fetchObjectDetails(uuid); if(!details) return;
+  const env={uuid,name:details.name,materials:details.materials||[],selectedMaterial:0,transform:{position:[0,0,0],rotation:[0,0,0],scale:[1,1,1]}};
+  state.setEnvironment(env);
+  envModal.style.display='none';
+  loadEnvironment(env);
+});
+  removeEnvBtn.addEventListener('click',()=>{
+    state.removeEnvironment();
+    if(envMesh){
+      if(transform.object===envMesh) transform.detach();
+      scene.remove(envMesh); envMesh=null;
+    }
+    setHovered(hovered && hovered.userData?.envObj ? null : hovered);
+    envModal.style.display='none';
+    updateCoordInputs();
+  });
+
+function updateTransformButtons() {
+  moveBtn.classList.toggle('active', transformMode === 'translate');
+  rotateBtn.classList.toggle('active', transformMode === 'rotate');
+  scaleBtn.classList.toggle('active', transformMode === 'scale');
+  noneBtn.classList.toggle('active', transformMode === null);
+}
+
+function setTransformMode(mode) {
+  if (mode === transformMode) {
+    if (mode === null) return; // already none
+    transformMode = null;
+  } else {
+    transformMode = mode;
+  }
+
+  if (transformMode === null) {
+    transform.enabled = false;
+    transform.detach();
+  } else {
+    transform.setMode(transformMode);
+    transform.enabled = true;
+    const mesh = transform.object || meshes[state.currentSlot?.id];
+    if (mesh) transform.attach(mesh);
+  }
+
+  updateTransformButtons();
+  updateCoordInputs();
+}
+
+moveBtn.addEventListener('click', () => setTransformMode('translate'));
+rotateBtn.addEventListener('click', () => setTransformMode('rotate'));
+scaleBtn.addEventListener('click', () => setTransformMode('scale'));
+noneBtn.addEventListener('click', () => setTransformMode(null));
+
+gridBtn.addEventListener('click', () => {
+  grid.visible = !grid.visible;
+  gridBtn.classList.toggle('active', grid.visible);
+});
+
+outlineBtn.addEventListener('click', () => {
+  outlinePass.enabled = !outlinePass.enabled;
+  outlineBtn.classList.toggle('active', outlinePass.enabled);
+});
+
+renderer.domElement.addEventListener('pointerdown', e => {
+  if (e.button !== 0) return;
+  pointerDown = { x: e.clientX, y: e.clientY };
+  pointerMoved = false;
+});
+
+renderer.domElement.addEventListener('pointermove', e => {
+  handleHover(e);
+  if (!pointerDown) return;
+  if (Math.abs(e.clientX - pointerDown.x) > 5 || Math.abs(e.clientY - pointerDown.y) > 5) {
+    pointerMoved = true;
+  }
+});
+
+renderer.domElement.addEventListener('pointerleave', () => {
+  setHovered(null);
+});
+
+renderer.domElement.addEventListener('pointerup', e => {
+  if (e.button !== 0 || !pointerDown) return;
+  if (!pointerMoved) handleSceneClick(e);
+  handleHover(e);
+  pointerDown = null;
+});
+
+inheritBtn.addEventListener('click', () => {
+  const slot = state.currentSlot;
+  state.inheritFromFirst(slot);
+  if (slot) loadSlot(slot, true);
+});
+
+function renderVarModal(slot){
+  varList.innerHTML='';
+  slot.objects.forEach((obj,oIdx)=>{
+    obj.materials.forEach((mat,mIdx)=>{
+      const row=document.createElement('div');
+      row.className='var-row';
+      const label=document.createElement('label');
+      label.textContent=`${obj.name} - ${mat.name}`;
+      const input=document.createElement('input');
+      input.type='text';
+      input.value=obj.colorNames?.[mIdx] || `${obj.name} ${mat.name}`;
+      input.dataset.idx=`${oIdx}-${mIdx}`;
+      row.appendChild(label);
+      row.appendChild(input);
+      varList.appendChild(row);
+    });
+  });
+}
+
+canBeEmptyChk.addEventListener('change', () => {
+  const slot = state.currentSlot;
+  if (slot) slot.canBeEmpty = canBeEmptyChk.checked;
+});
+
+textButtonsChk.addEventListener('change', () => {
+  const slot = state.currentSlot;
+  if (slot) slot.textButtons = textButtonsChk.checked;
+});
+
+slotSettingsBtn.addEventListener('click', () => {
+  const slot = state.currentSlot;
+  if (!slot) return;
+  renderVarModal(slot);
+  varModal.style.display = 'block';
+});
+
+closeVarBtn.addEventListener('click', () => {
+  varModal.style.display = 'none';
+});
+
+saveVarBtn.addEventListener('click', () => {
+  const slot = state.currentSlot;
+  if (!slot) { varModal.style.display = 'none'; return; }
+  varList.querySelectorAll('input').forEach(inp => {
+    const [oIdx, mIdx] = inp.dataset.idx.split('-').map(Number);
+    if (!slot.objects[oIdx].colorNames) slot.objects[oIdx].colorNames = [];
+    slot.objects[oIdx].colorNames[mIdx] = inp.value;
+  });
+  varModal.style.display = 'none';
+});
+
+async function handleImport(data) {
+  reloadScene();
+  setTransformMode(null);
+  await state.importJSON(data, fetchObjectDetails);
+  renderVariants();
+  renderUI();
+  canBeEmptyChk.checked = state.currentSlot?.canBeEmpty || false;
+  textButtonsChk.checked = state.currentSlot?.textButtons || false;
+  reloadScene();
+}
+
+// initialize
+state.addSlot();
+
+function renderUI(){
+  if(state.currentStepIndex>=state.steps.length) state.currentStepIndex = 0;
+  const step = state.currentStep;
+  stepNameEl.textContent = step.name;
+  stepControls.style.display = state.steps.length>1 ? 'flex' : 'none';
+  renderVariants();
+  if(state.currentSlotIndex !== -1 && state.currentSlot?.stepId !== step.id){
+    const idx = state.slots.findIndex(s=>s.stepId===step.id);
+    state.currentSlotIndex = idx;
+  }
+  if(isMobile()){
+    objectsContainer.parentElement.style.display='none';
+    renderSlotsMobile(state, slotListEl, slotCallbacks, objectCallbacks, step.id);
+  }else{
+    objectsContainer.parentElement.style.display='block';
+    renderSlots(state, slotListEl, slotCallbacks, step.id);
+    renderObjects(state.currentSlot, objectsContainer, objectCallbacks);
+  }
+  canBeEmptyChk.checked = state.currentSlot?.canBeEmpty || false;
+  textButtonsChk.checked = state.currentSlot?.textButtons || false;
+  updatePanels();
+}
+
+renderUI();
+canBeEmptyChk.checked = state.currentSlot?.canBeEmpty || false;
+textButtonsChk.checked = state.currentSlot?.textButtons || false;
+activateSlot(state.currentSlot);
+updateTransformButtons();
+reloadScene();

--- a/js/main.js
+++ b/js/main.js
@@ -95,7 +95,6 @@ new RGBELoader().load(
   (hdr) => {
     const envMap = pmrem.fromEquirectangular(hdr).texture;
     scene.environment = envMap;
-    scene.background = envMap;
     hdr.dispose();
     pmrem.dispose();
   }

--- a/js/modal.js
+++ b/js/modal.js
@@ -1,0 +1,200 @@
+import { fetchObjects } from './api.js';
+
+let lastPage = 1;
+
+export function openObjectModal(modalEl, { onSelect }) {
+  const listEl = modalEl.querySelector('#modalList');
+  const pageInfo = modalEl.querySelector('#pageInfo');
+  const prevBtn = modalEl.querySelector('#prevPage');
+  const nextBtn = modalEl.querySelector('#nextPage');
+  const closeBtn = modalEl.querySelector('#closeModal');
+  let currentPage = lastPage;
+  let totalPages = 1;
+
+  async function load(page) {
+    const data = await fetchObjects(page);
+    listEl.innerHTML = '';
+    data.objs.forEach(obj => {
+      const card = document.createElement('div');
+      card.className = 'modal-card';
+
+      const thumb = document.createElement('div');
+      thumb.className = 'thumb';
+      const img = document.createElement('img');
+      img.src = obj.preview?.subRes?.small || obj.preview?.url || '';
+      thumb.appendChild(img);
+      const overlay = document.createElement('div');
+      overlay.className = 'overlay';
+      const title = document.createElement('p');
+      title.textContent = obj.name;
+      thumb.appendChild(overlay);
+      thumb.appendChild(title);
+      card.appendChild(thumb);
+
+      const info = document.createElement('div');
+      info.className = 'info';
+
+      const owner = document.createElement('div');
+      owner.className = 'owner';
+      const avatar = document.createElement('span');
+      avatar.className = 'avatar';
+      avatar.textContent = obj.owner?.name ? obj.owner.name[0] : '';
+      owner.appendChild(avatar);
+      const ownerName = document.createElement('p');
+      ownerName.textContent = obj.owner?.name || '';
+      owner.appendChild(ownerName);
+      info.appendChild(owner);
+
+      const counts = document.createElement('div');
+      counts.className = 'counts';
+      const viewsWrap = document.createElement('div');
+      viewsWrap.className = 'count';
+      viewsWrap.innerHTML = `<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M21.8701 11.496C21.2301 10.386 17.7101 4.81597 11.7301 4.99597C6.20007 5.13597 3.00007 9.99597 2.13007 11.496C2.0423 11.648 1.99609 11.8204 1.99609 11.996C1.99609 12.1715 2.0423 12.3439 2.13007 12.496C2.76007 13.586 6.13007 18.996 12.0201 18.996H12.2701C17.8001 18.856 21.0101 13.996 21.8701 12.496C21.9577 12.3439 22.0039 12.1715 22.0039 11.996C22.0039 11.8204 21.9577 11.648 21.8701 11.496ZM12.0001 15.496C11.5355 15.5038 11.0741 15.4191 10.6426 15.2468C10.2112 15.0744 9.81833 14.8179 9.48704 14.4922C9.15575 14.1664 8.89263 13.778 8.71302 13.3495C8.53341 12.921 8.44091 12.4611 8.44091 11.9965C8.44091 11.5319 8.53341 11.0719 8.71302 10.6434C8.89263 10.2149 9.15575 9.8265 9.48704 9.50076C9.81833 9.17503 10.2112 8.91851 10.6426 8.74617C11.0741 8.57383 11.5355 8.48911 12.0001 8.49697C12.9283 8.49697 13.8186 8.86571 14.4749 9.52209C15.1313 10.1785 15.5001 11.0687 15.5001 11.997C15.5001 12.9252 15.1313 13.8155 14.4749 14.4718C13.8186 15.1282 12.9283 15.496 12.0001 15.496Z" fill="currentColor"></path></svg>`;
+      const viewsCount = document.createElement('p');
+      viewsCount.textContent = obj.viewsShowcase ?? obj.views ?? 0;
+      viewsWrap.appendChild(viewsCount);
+      counts.appendChild(viewsWrap);
+
+      const likesWrap = document.createElement('div');
+      likesWrap.className = 'count';
+      likesWrap.innerHTML = `<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M16.6011 3.12072C17.2514 3.15332 17.8923 3.29981 18.4951 3.55427C19.1836 3.84496 19.8093 4.27105 20.3362 4.80801L20.529 5.01393C20.9663 5.50534 21.3179 6.07062 21.5676 6.68471C21.853 7.38644 22 8.13895 22 8.89853C22 9.65809 21.853 10.4106 21.5676 11.1123C21.3559 11.633 21.0701 12.1178 20.7217 12.5529L20.6953 12.6902L20.5861 12.7892L20.0693 13.2592L19.411 13.9317L12.617 20.8529C12.2973 21.1786 11.7917 21.1995 11.4487 20.9146L11.3822 20.8529L3.6629 12.9882C2.59837 11.9035 2.00003 10.4325 2 8.89853C2.00006 7.36455 2.59828 5.8927 3.6629 4.80801C4.72748 3.72355 6.17147 3.11471 7.67689 3.11464C9.18247 3.11464 10.6271 3.72339 11.6917 4.80801L11.9996 5.12167L12.3074 4.80801C12.8345 4.27085 13.4607 3.84502 14.1494 3.55427C14.8382 3.2635 15.5767 3.11377 16.3223 3.11377L16.6011 3.12072Z" fill="currentColor"></path></svg>`;
+      const likesCount = document.createElement('p');
+      likesCount.textContent = obj.likes ?? 0;
+      likesWrap.appendChild(likesCount);
+      counts.appendChild(likesWrap);
+
+      info.appendChild(counts);
+      card.appendChild(info);
+
+      card.addEventListener('click', () => {
+        onSelect(obj);
+        close();
+      });
+
+      listEl.appendChild(card);
+    });
+    currentPage = page;
+    lastPage = currentPage;
+    totalPages = data.pages_count || 1;
+    pageInfo.textContent = `${currentPage}/${totalPages}`;
+    prevBtn.disabled = currentPage <= 1;
+    nextBtn.disabled = currentPage >= totalPages;
+  }
+
+  function close() {
+    modalEl.style.display = 'none';
+    prevBtn.removeEventListener('click', prev);
+    nextBtn.removeEventListener('click', next);
+    closeBtn.removeEventListener('click', close);
+  }
+
+  function prev() {
+    if (currentPage > 1) load(currentPage - 1);
+  }
+  function next() {
+    if (currentPage < totalPages) load(currentPage + 1);
+  }
+
+  prevBtn.addEventListener('click', prev);
+  nextBtn.addEventListener('click', next);
+  closeBtn.addEventListener('click', close);
+
+  modalEl.style.display = 'block';
+  load(currentPage);
+}
+
+export function openStepsModal(modalEl, state, onSave) {
+  const listEl = modalEl.querySelector('#stepsList');
+  const addBtn = modalEl.querySelector('#addStep');
+  const saveBtn = modalEl.querySelector('#saveSteps');
+  const closeBtn = modalEl.querySelector('#closeSteps');
+
+  function render() {
+    listEl.innerHTML = '';
+    state.steps.forEach((step) => {
+      const row = document.createElement('div');
+      row.className = 'step-row';
+      const header = document.createElement('div');
+      header.className = 'step-header';
+      const name = document.createElement('input');
+      name.value = step.name;
+      header.appendChild(name);
+      const del = document.createElement('button');
+      del.textContent = 'Delete';
+      del.className = 'action-btn';
+      del.addEventListener('click', () => {
+        if(state.steps.length<=1) return;
+        const idx = state.steps.indexOf(step);
+        const removed = state.steps.splice(idx,1)[0];
+        state.slots.forEach(s=>{ if(s.stepId===removed.id) s.stepId = state.steps[0].id; });
+        if(state.currentStepIndex>=state.steps.length) state.currentStepIndex=0;
+        render();
+      });
+      header.appendChild(del);
+      row.appendChild(header);
+      const checks = document.createElement('div');
+      checks.className = 'slot-checks';
+      state.slots.forEach((slot) => {
+        const label = document.createElement('label');
+        const chk = document.createElement('input');
+        chk.type = 'checkbox';
+        chk.checked = slot.stepId === step.id;
+        chk.dataset.slot = slot.id;
+        chk.addEventListener('change', () => {
+          if (chk.checked) {
+            listEl.querySelectorAll(`input[data-slot="${slot.id}"]`).forEach((other) => {
+              if (other !== chk) other.checked = false;
+            });
+          }
+        });
+        label.appendChild(chk);
+        label.appendChild(document.createTextNode(slot.name));
+        checks.appendChild(label);
+      });
+      row.appendChild(checks);
+      row._name = name;
+      listEl.appendChild(row);
+    });
+  }
+
+  function addStep() {
+    state.addStep(`Step ${state.steps.length + 1}`);
+    render();
+  }
+
+  function save() {
+    const rows = Array.from(listEl.children);
+    rows.forEach((row, idx) => {
+      const step = state.steps[idx];
+      step.name = row._name.value;
+      step.index = idx;
+    });
+    state.slots.forEach((slot) => {
+      const checked = listEl.querySelector(`input[data-slot="${slot.id}"]:checked`);
+      if (checked) {
+        const stepIdx = rows.indexOf(checked.closest('.step-row'));
+        slot.stepId = state.steps[stepIdx].id;
+      } else {
+        slot.stepId = state.steps[0].id;
+      }
+    });
+    modalEl.style.display = 'none';
+    addBtn.removeEventListener('click', addStep);
+    saveBtn.removeEventListener('click', save);
+    closeBtn.removeEventListener('click', close);
+    onSave();
+  }
+
+  function close() {
+    modalEl.style.display = 'none';
+    addBtn.removeEventListener('click', addStep);
+    saveBtn.removeEventListener('click', save);
+    closeBtn.removeEventListener('click', close);
+  }
+
+  addBtn.addEventListener('click', addStep);
+  saveBtn.addEventListener('click', save);
+  closeBtn.addEventListener('click', close);
+  modalEl.style.display = 'block';
+  render();
+}

--- a/js/state.js
+++ b/js/state.js
@@ -1,0 +1,294 @@
+export class ConfiguratorState {
+  constructor() {
+    this.variants = [];
+    this.currentVariantIndex = 0;
+    this.currentSlotIndex = -1;
+    this.currentStepIndex = 0;
+    this.environment = null;
+    const def = this._createVariant('Variant 1');
+    this.variants.push(def);
+  }
+
+  get currentVariant() { return this.variants[this.currentVariantIndex]; }
+  get steps() { return this.currentVariant.steps; }
+  get slots() { return this.currentVariant.slots; }
+  get viewPoint() { return this.currentVariant.viewPoint; }
+
+  _createVariant(name) {
+    const step = { id: crypto.randomUUID(), name: 'Step 1', index: 0 };
+    return {
+      id: crypto.randomUUID(),
+      name,
+      steps: [step],
+      slots: [],
+      viewPoint: {
+        position: [0,0,0],
+        rotation: [0,0,0],
+        left: 0,
+        right: 0,
+        down: 0,
+        up: 0,
+        maxDistance: 0,
+        allowMovement: false,
+        enabled: false,
+        hidden: false
+      }
+    };
+  }
+
+  _cloneVariant(src, name) {
+    const stepMap = new Map();
+    const steps = src.steps.map(s => {
+      const id = crypto.randomUUID();
+      stepMap.set(s.id, id);
+      return { id, name: s.name, index: s.index };
+    });
+    const slots = src.slots.map(s => ({
+      id: crypto.randomUUID(),
+      name: s.name,
+      objects: s.objects.map(o => ({
+        uuid: o.uuid,
+        name: o.name,
+        materials: o.materials,
+        selectedMaterial: o.selectedMaterial,
+        colorNames: [...(o.colorNames || o.materials.map(m=>m.name))],
+        transform: {
+          position: [...o.transform.position],
+          rotation: [...o.transform.rotation],
+          scale: [...o.transform.scale]
+        }
+      })),
+      selectedObjectIndex: s.selectedObjectIndex,
+      canBeEmpty: s.canBeEmpty,
+      hidden: s.hidden,
+      textButtons: s.textButtons || false,
+      stepId: stepMap.get(s.stepId) || steps[0].id
+    }));
+    const viewPoint = {
+      position: [...src.viewPoint.position],
+      rotation: [...src.viewPoint.rotation],
+      left: src.viewPoint.left,
+      right: src.viewPoint.right,
+      down: src.viewPoint.down,
+      up: src.viewPoint.up,
+      maxDistance: src.viewPoint.maxDistance,
+      allowMovement: src.viewPoint.allowMovement,
+      enabled: src.viewPoint.enabled || false,
+      hidden: src.viewPoint.hidden || false
+    };
+    return { id: crypto.randomUUID(), name, steps, slots, viewPoint };
+  }
+
+  addVariant(name = `Variant ${this.variants.length + 1}`) {
+    const base = this.currentVariant;
+    const v = this._cloneVariant(base, name);
+    this.variants.push(v);
+    this.currentVariantIndex = this.variants.length - 1;
+    this.currentSlotIndex = base.slots.length ? 0 : -1;
+    this.currentStepIndex = 0;
+    return v;
+  }
+
+  deleteCurrentVariant() {
+    if (this.variants.length <= 1) return;
+    this.variants.splice(this.currentVariantIndex, 1);
+    if (this.currentVariantIndex >= this.variants.length) this.currentVariantIndex = 0;
+    this.currentSlotIndex = -1;
+    this.currentStepIndex = 0;
+  }
+
+  renameCurrentVariant(name) {
+    this.currentVariant.name = name;
+  }
+
+  clearVariant() {
+    const v = this.currentVariant;
+    const def = { id: crypto.randomUUID(), name: 'Step 1', index: 0 };
+    v.steps = [def];
+    v.slots = [];
+    this.currentSlotIndex = -1;
+    this.currentStepIndex = 0;
+  }
+
+  addSlot(name = 'New slot') {
+    const stepId = this.currentStep ? this.currentStep.id : this.steps[0].id;
+    const slot = {
+      id: crypto.randomUUID(),
+      name,
+      objects: [],
+      selectedObjectIndex: -1,
+      canBeEmpty: false,
+      hidden: false,
+      textButtons: false,
+      stepId
+    };
+    this.slots.push(slot);
+    this.currentSlotIndex = this.slots.length - 1;
+    return slot;
+  }
+
+  addSlotFromData(id, name, objects = [], canBeEmpty = false, stepId = this.steps[0].id, textButtons = false) {
+    const slot = {
+      id,
+      name,
+      objects,
+      selectedObjectIndex: objects.length ? 0 : -1,
+      canBeEmpty,
+      hidden: false,
+      textButtons,
+      stepId
+    };
+    this.slots.push(slot);
+    if (this.currentSlotIndex === -1) this.currentSlotIndex = 0;
+    return slot;
+  }
+
+  removeSlot(id) {
+    const idx = this.slots.findIndex(s => s.id === id);
+    if (idx !== -1) {
+      const stepId = this.slots[idx].stepId;
+      this.slots.splice(idx, 1);
+      const stepSlots = this.slots.filter(s => s.stepId === stepId);
+      const target = stepSlots[0] ? this.slots.indexOf(stepSlots[0]) : this.slots[0] ? 0 : -1;
+      this.currentSlotIndex = target;
+    }
+  }
+
+  get currentSlot() { return this.slots[this.currentSlotIndex]; }
+
+  addObjectToCurrent(objectData) {
+    if (!this.currentSlot) return null;
+    const obj = {
+      uuid: objectData.uuid,
+      name: objectData.name,
+      materials: objectData.materials || [],
+      selectedMaterial: 0,
+      colorNames: (objectData.materials || []).map(m=>m.name),
+      transform: { position: [0,0,0], rotation:[0,0,0], scale:[1,1,1] }
+    };
+    this.currentSlot.objects.push(obj);
+    this.currentSlot.selectedObjectIndex = this.currentSlot.objects.length - 1;
+    return obj;
+  }
+
+  inheritFromFirst(slot){
+    if(!slot || slot.objects.length<2) return;
+    const first = slot.objects[0];
+    slot.objects.slice(1).forEach(o=>{
+      o.transform.position=[...first.transform.position];
+      o.transform.rotation=[...first.transform.rotation];
+    });
+  }
+
+  addStep(name){
+    const step={id:crypto.randomUUID(),name,index:this.steps.length};
+    this.steps.push(step);
+    return step;
+  }
+
+  setEnvironment(obj){
+    this.environment = obj;
+  }
+
+  removeEnvironment(){ this.environment = null; }
+
+  get currentStep(){ return this.steps[this.currentStepIndex]; }
+
+  async importJSON(data, fetchDetails){
+    this.variants=[];
+    if(data.variants){
+      for(const [vid,vdata] of Object.entries(data.variants)){
+        const variant=this._createVariant(vdata.name||'Variant');
+        variant.id=vid;
+        variant.viewPoint={
+          position:vdata.viewPoint?.position||[0,0,0],
+          rotation:vdata.viewPoint?.rotation||[0,0,0],
+          left:vdata.viewPoint?.left||0,
+          right:vdata.viewPoint?.right||0,
+          down:vdata.viewPoint?.down||0,
+          up:vdata.viewPoint?.up||0,
+          maxDistance:vdata.viewPoint?.maxDistance||0,
+          allowMovement:!!vdata.viewPoint?.allowMovement,
+          enabled:!!vdata.viewPoint?.enabled,
+          hidden:!!vdata.viewPoint?.hidden
+        };
+        variant.steps = Object.entries(vdata.steps||{}).map(([id,s])=>({id,name:s.name,index:s.index||0}));
+        if(!variant.steps.length) variant.steps=[{id:crypto.randomUUID(),name:'Step 1',index:0}];
+        variant.steps.sort((a,b)=>a.index-b.index);
+        for(const [sid,slotData] of Object.entries(vdata.slots||{})){
+          const objects=[];
+          for(const objData of slotData.objects||[]){
+            const det=await fetchDetails(objData.uuid); if(!det) continue;
+            objects.push({uuid:objData.uuid,name:det.name,materials:det.materials||[],selectedMaterial:0,colorNames:objData.colorNames||objData.variationNames||((det.materials||[]).map(m=>m.name)),transform:{position:objData.position||[0,0,0],rotation:objData.rotation||[0,0,0],scale:objData.scale||[1,1,1]}});
+          }
+          variant.slots.push({id:sid,name:slotData.name,objects,selectedObjectIndex:objects.length?0:-1,canBeEmpty:slotData.canBeEmpty,hidden:false,textButtons:slotData.textButtons||false,stepId:slotData.step||variant.steps[0].id});
+        }
+        this.variants.push(variant);
+      }
+    } else {
+      const variant=this._createVariant('Variant 1');
+      variant.viewPoint={
+        position:data.viewPoint?.position||[0,0,0],
+        rotation:data.viewPoint?.rotation||[0,0,0],
+        left:data.viewPoint?.left||0,
+        right:data.viewPoint?.right||0,
+        down:data.viewPoint?.down||0,
+        up:data.viewPoint?.up||0,
+        maxDistance:data.viewPoint?.maxDistance||0,
+        allowMovement:!!data.viewPoint?.allowMovement,
+        enabled:!!data.viewPoint?.enabled,
+        hidden:!!data.viewPoint?.hidden
+      };
+      variant.steps = Object.entries(data.steps||{}).map(([id,s])=>({id,name:s.name,index:s.index||0}));
+      if(!variant.steps.length) variant.steps=[{id:crypto.randomUUID(),name:'Step 1',index:0}];
+      variant.steps.sort((a,b)=>a.index-b.index);
+      for(const [id,slotData] of Object.entries(data.slots||{})){
+        const objects=[];
+        for(const objData of slotData.objects||[]){
+          const det=await fetchDetails(objData.uuid); if(!det) continue;
+          objects.push({uuid:objData.uuid,name:det.name,materials:det.materials||[],selectedMaterial:0,colorNames:objData.colorNames||objData.variationNames||((det.materials||[]).map(m=>m.name)),transform:{position:objData.position||[0,0,0],rotation:objData.rotation||[0,0,0],scale:objData.scale||[1,1,1]}});
+        }
+        variant.slots.push({id,name:slotData.name,objects,selectedObjectIndex:objects.length?0:-1,canBeEmpty:slotData.canBeEmpty,hidden:false,textButtons:slotData.textButtons||false,stepId:slotData.step||variant.steps[0].id});
+      }
+      this.variants.push(variant);
+    }
+    if(data.environment){
+      const det=await fetchDetails(data.environment.uuid);
+      if(det) this.environment={uuid:data.environment.uuid,name:det.name,materials:det.materials||[],selectedMaterial:0,transform:{position:data.environment.position||[0,0,0],rotation:data.environment.rotation||[0,0,0],scale:data.environment.scale||[1,1,1]}};
+    } else {
+      this.environment=null;
+    }
+    this.currentVariantIndex=0;
+    this.currentStepIndex=0;
+    const firstIdx=this.slots.findIndex(s=>s.stepId===this.currentStep.id);
+    this.currentSlotIndex=firstIdx;
+  }
+
+  exportJSON(){
+    const variantsOut={};
+    this.variants.forEach(variant=>{
+      const stepsOut={};
+      variant.steps.forEach(step=>{stepsOut[step.id]={name:step.name,index:step.index};});
+      const slotsOut={};
+      variant.slots.forEach(slot=>{
+        slotsOut[slot.id]={name:slot.name,canBeEmpty:slot.canBeEmpty,textButtons:slot.textButtons,step:slot.stepId,objects:slot.objects.map(o=>({uuid:o.uuid,position:o.transform.position,rotation:o.transform.rotation,scale:o.transform.scale,colorNames:o.colorNames}))};
+      });
+      const out={name:variant.name,steps:stepsOut,slots:slotsOut,viewPoint:{
+        position:variant.viewPoint.position,
+        rotation:variant.viewPoint.rotation,
+        left:variant.viewPoint.left,
+        right:variant.viewPoint.right,
+        down:variant.viewPoint.down,
+        up:variant.viewPoint.up,
+        maxDistance:variant.viewPoint.maxDistance,
+        allowMovement:variant.viewPoint.allowMovement,
+        enabled:variant.viewPoint.enabled,
+        hidden:variant.viewPoint.hidden
+      }};
+      variantsOut[variant.id]=out;
+    });
+    const out={version:2,variants:variantsOut};
+    if(this.environment){ out.environment={uuid:this.environment.uuid,position:this.environment.transform.position,rotation:this.environment.transform.rotation,scale:this.environment.transform.scale}; }
+    return JSON.stringify(out,null,2);
+  }
+}

--- a/js/ui.js
+++ b/js/ui.js
@@ -1,0 +1,189 @@
+export function renderSlots(state, container, { onSelect, onDelete, onToggleHide }, stepId) {
+  container.innerHTML = '';
+  const vp = document.createElement('li');
+  vp.className = 'slot' + (state.currentSlotIndex === -1 ? ' selected' : '');
+  vp.addEventListener('click', () => onSelect('view'));
+  const nameSpan = document.createElement('span');
+  nameSpan.textContent = 'Point view';
+  const settingsBtn = document.createElement('button');
+  settingsBtn.textContent = 'Setting view';
+  settingsBtn.className = 'action-btn';
+  settingsBtn.addEventListener('click', e => {
+    e.stopPropagation();
+    document.getElementById('viewBtn')?.click();
+  });
+  const hideBtn = document.createElement('button');
+  hideBtn.textContent = 'Hide';
+  hideBtn.className = 'hide-btn' + (state.viewPoint.hidden ? ' active' : '');
+  hideBtn.addEventListener('click', e => { e.stopPropagation(); onToggleHide('view'); });
+  const actions = document.createElement('div');
+  actions.className = 'slot-actions';
+  actions.appendChild(settingsBtn);
+  actions.appendChild(hideBtn);
+  vp.appendChild(nameSpan);
+  vp.appendChild(actions);
+  container.appendChild(vp);
+  state.slots.filter(s=>s.stepId===stepId).forEach((slot) => {
+    const index = state.slots.indexOf(slot);
+    const li = document.createElement('li');
+    li.className = 'slot' + (index === state.currentSlotIndex ? ' selected' : '');
+    li.addEventListener('click', () => {
+      if (state.currentSlotIndex === index) {
+        const newName = prompt('Rename slot', slot.name);
+        if (newName) {
+          slot.name = newName;
+          renderSlots(state, container, { onSelect, onDelete, onToggleHide }, stepId);
+        }
+        } else {
+          onSelect(index);
+        }
+      });
+    const nameSpan = document.createElement('span');
+    nameSpan.textContent = slot.name;
+    const hideBtn = document.createElement('button');
+    hideBtn.textContent = 'Hide';
+    hideBtn.className = 'hide-btn' + (slot.hidden ? ' active' : '');
+    hideBtn.addEventListener('click', e => {
+      e.stopPropagation();
+      onToggleHide(slot);
+    });
+    const delBtn = document.createElement('button');
+    delBtn.textContent = 'X';
+    delBtn.className = 'action-btn';
+    delBtn.addEventListener('click', e => {
+      e.stopPropagation();
+      onDelete(slot.id);
+    });
+    const actions = document.createElement('div');
+    actions.className = 'slot-actions';
+    actions.appendChild(hideBtn);
+    actions.appendChild(delBtn);
+    li.appendChild(nameSpan);
+    li.appendChild(actions);
+    container.appendChild(li);
+  });
+}
+
+export function renderObjects(slot, container, { onSelectObject, onSelectMaterial, onDelete }) {
+  container.innerHTML = '';
+  if (!slot) return;
+  slot.objects.forEach((obj, objIndex) => {
+    const card = document.createElement('div');
+    card.className = 'obj-card' + (objIndex === slot.selectedObjectIndex ? ' selected' : '');
+    const title = document.createElement('div');
+    title.textContent = obj.name;
+    title.addEventListener('click', () => onSelectObject(objIndex));
+    const delBtn = document.createElement('button');
+    delBtn.textContent = 'Delete';
+    delBtn.className = 'action-btn';
+    delBtn.addEventListener('click', () => onDelete(objIndex));
+    const matList = document.createElement('div');
+    matList.className = 'material-list';
+    obj.materials.forEach((mat, matIndex) => {
+      const btn = document.createElement('button');
+      const img = document.createElement('img');
+      const url = mat.previews?.[0]?.subRes?.small || mat.previews?.[0]?.url;
+      img.src = url || '';
+      img.alt = mat.name;
+      btn.appendChild(img);
+      btn.addEventListener('click', e => {
+        e.stopPropagation();
+        onSelectMaterial(objIndex, matIndex);
+      });
+      if (objIndex === slot.selectedObjectIndex && matIndex === obj.selectedMaterial) {
+        btn.classList.add('selected');
+        const check=document.createElement('span');
+        check.className='check';
+        const chkImg=document.createElement('img');
+        chkImg.src='https://cdn.jsdelivr.net/npm/lucide-static@0.452.0/icons/check.svg';
+        check.appendChild(chkImg);
+        btn.appendChild(check);
+      }
+      matList.appendChild(btn);
+    });
+    card.appendChild(title);
+    card.appendChild(delBtn);
+    card.appendChild(matList);
+    container.appendChild(card);
+  });
+}
+
+export function renderSlotsMobile(state, container, slotCallbacks, objectCallbacks, stepId){
+  container.innerHTML='';
+  const vp=document.createElement('details');
+  vp.className='slot-mobile';
+  const sum=document.createElement('summary');
+  sum.textContent='Point view';
+  sum.addEventListener('click',e=>{slotCallbacks.onSelect('view');});
+  const actions=document.createElement('span');
+  actions.className='slot-actions';
+  const settings=document.createElement('button');
+  settings.textContent='Setting view';
+  settings.className='action-btn';
+  settings.addEventListener('click',e=>{e.stopPropagation();document.getElementById('viewBtn')?.click();});
+  const hide=document.createElement('button');
+  hide.textContent='Hide';
+  hide.className='hide-btn'+(state.viewPoint.hidden?' active':'');
+  hide.addEventListener('click',e=>{e.stopPropagation();slotCallbacks.onToggleHide('view');});
+  actions.appendChild(settings);
+  actions.appendChild(hide);
+  sum.appendChild(actions);
+  vp.appendChild(sum);
+  container.appendChild(vp);
+  state.slots.filter(s=>s.stepId===stepId).forEach((slot)=>{
+    const index = state.slots.indexOf(slot);
+    const det=document.createElement('details');
+    det.className='slot-mobile';
+    det.open = slot._mobileOpen || false;
+    det.addEventListener('toggle',()=>{slot._mobileOpen = det.open;});
+    const sum=document.createElement('summary');
+    sum.textContent=slot.name;
+    sum.addEventListener('click',e=>{
+      if(state.currentSlotIndex===index){
+        if(e.detail===2){
+          const newName=prompt('Rename slot',slot.name);
+          if(newName){slot.name=newName;renderSlotsMobile(state,container,slotCallbacks,objectCallbacks,stepId);} }
+      }else{
+        slotCallbacks.onSelect(index);
+      }
+    });
+    const actions=document.createElement('span');
+    actions.className='slot-actions';
+    const hide=document.createElement('button');
+    hide.textContent='Hide';
+    hide.className='hide-btn'+(slot.hidden?' active':'');
+    hide.addEventListener('click',e=>{e.stopPropagation();slotCallbacks.onToggleHide(slot);renderSlotsMobile(state,container,slotCallbacks,objectCallbacks,stepId);});
+    const del=document.createElement('button');
+    del.textContent='X';
+    del.className='action-btn';
+    del.addEventListener('click',e=>{e.stopPropagation();slotCallbacks.onDelete(slot.id);renderSlotsMobile(state,container,slotCallbacks,objectCallbacks,stepId);});
+    actions.appendChild(hide);actions.appendChild(del);sum.appendChild(actions);
+    det.appendChild(sum);
+    const body=document.createElement('div');
+    slot.objects.forEach((obj,objIndex)=>{
+      const card=document.createElement('div');
+      card.className='obj-card'+(objIndex===slot.selectedObjectIndex?' selected':'');
+      const title=document.createElement('div');
+      title.textContent=obj.name;
+      title.addEventListener('click',()=>{state.currentSlotIndex=index;objectCallbacks.onSelectObject(objIndex);});
+      const delBtn=document.createElement('button');
+      delBtn.textContent='Delete';
+      delBtn.className='action-btn';
+      delBtn.addEventListener('click',()=>{state.currentSlotIndex=index;objectCallbacks.onDelete(objIndex);renderSlotsMobile(state,container,slotCallbacks,objectCallbacks,stepId);});
+      const matList=document.createElement('div');
+      matList.className='material-list';
+      obj.materials.forEach((mat,matIndex)=>{
+        const btn=document.createElement('button');
+        const img=document.createElement('img');
+        const url=mat.previews?.[0]?.subRes?.small||mat.previews?.[0]?.url;
+        img.src=url||'';img.alt=mat.name;btn.appendChild(img);
+        btn.addEventListener('click',e=>{e.stopPropagation();state.currentSlotIndex=index;objectCallbacks.onSelectMaterial(objIndex,matIndex);renderSlotsMobile(state,container,slotCallbacks,objectCallbacks,stepId);});
+        if(objIndex===slot.selectedObjectIndex && matIndex===obj.selectedMaterial){btn.classList.add('selected');}
+        matList.appendChild(btn);
+      });
+      card.appendChild(title);card.appendChild(delBtn);card.appendChild(matList);body.appendChild(card);
+    });
+    det.appendChild(body);
+    container.appendChild(det);
+  });
+}

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,117 @@
+:root {
+  --color-Brand-Main: #4356f2;
+  --color-Gray-10: #e3e5e8;
+  --color-Gray-20: #c6cad2;
+  --color-Gray-70: #3f485a;
+  --color-Borders-Main: #dbdbdb;
+  --color-Text-Main: #3f485a;
+  --color-White: #fff;
+  --color-check: #22C55E;
+}
+
+body,html{margin:0;padding:0;height:100%;overflow:hidden;font-family:Inter,sans-serif;color:var(--color-Text-Main);}
+#container{display:flex;height:100%;}
+#slotsPanel{width:20%;background:var(--color-Gray-10);padding:10px;display:flex;flex-direction:column;}
+#objectsPanel{width:20%;background:var(--color-Gray-10);overflow-y:auto;padding:10px;}
+#slotsPanel{border-right:1px solid var(--color-Borders-Main);}
+#variantControls{display:flex;gap:5px;margin-bottom:10px;align-items:center;}
+#variantControls select{flex:1;}
+#stepControls{display:flex;justify-content:center;align-items:center;gap:8px;margin-bottom:10px;}
+#objectsPanel{border-left:1px solid var(--color-Borders-Main);}
+#viewer{flex:1;position:relative;}
+canvas{display:block;}
+#bottomBtns{position:absolute;bottom:10px;left:50%;transform:translateX(-50%);}
+#bottomBtns button{margin:0 5px;}
+#transformBtns{position:absolute;top:10px;left:50%;transform:translateX(-50%);}
+#transformBtns button{margin:0 5px;}
+#coordsPanel{position:absolute;top:10px;right:10px;display:none;flex-direction:column;gap:5px;}
+#coordsPanel input{width:60px;text-align:center;background:var(--color-White);border:1px solid var(--color-Borders-Main);border-radius:4px;padding:4px;color:var(--color-Text-Main);}
+#coordsPanel input::-webkit-outer-spin-button,#coordsPanel input::-webkit-inner-spin-button{-webkit-appearance:none;margin:0;}
+#coordsPanel input[type=number]{-moz-appearance:textfield;}
+#objectActions{display:flex;gap:5px;margin-bottom:10px;}
+#slotOptions{display:flex;align-items:center;gap:5px;margin-bottom:10px;}
+#slotOptions label{display:flex;align-items:center;gap:4px;}
+#objectModal{position:fixed;top:10%;left:50%;transform:translateX(-50%);display:none;z-index:10;}
+#objectModal .modal-box{background:var(--color-White);border:1px solid var(--color-Borders-Main);width:60vw;max-height:80vh;padding:20px;overflow:auto;position:relative;}
+#modalList{display:grid;grid-template-columns:repeat(4,1fr);gap:16px;max-height:60vh;overflow:auto;}
+#objectModal .modal-card{display:flex;flex-direction:column;gap:8px;cursor:pointer;}
+#objectModal .modal-card .thumb{position:relative;width:100%;aspect-ratio:10/7;border-radius:6px;overflow:hidden;background:var(--color-White);}
+#objectModal .modal-card .thumb img{position:absolute;top:0;left:0;width:100%;height:100%;object-fit:cover;}
+#objectModal .modal-card .overlay{position:absolute;inset:0;pointer-events:none;background:rgba(0,0,0,0.06);}
+#objectModal .modal-card .overlay::after{content:'';position:absolute;inset:0;opacity:0;transition:opacity .2s;background:linear-gradient(180deg,rgba(0,0,0,0.1) 65.38%,rgba(2,2,2,0.6) 100%);}
+#objectModal .modal-card:hover .overlay::after{opacity:1;}
+#objectModal .modal-card .thumb p{position:absolute;bottom:5px;left:5px;color:#fff;font-weight:bold;font-size:16px;max-width:70%;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;opacity:0;transition:opacity .2s;}
+#objectModal .modal-card:hover .thumb p{opacity:1;}
+#objectModal .modal-card .info{display:flex;justify-content:space-between;gap:8px;padding:0 4px;font-size:12px;}
+#objectModal .modal-card .info .owner{display:flex;align-items:center;gap:6px;flex:1;min-width:0;}
+#objectModal .modal-card .info .avatar{display:flex;align-items:center;justify-content:center;width:24px;height:24px;border-radius:50%;overflow:hidden;background:#ddd;flex-shrink:0;font-size:12px;font-weight:bold;color:#555;}
+#objectModal .modal-card .info .owner p{font-weight:600;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
+#objectModal .modal-card .info .counts{display:flex;gap:8px;flex-shrink:0;align-items:center;}
+#objectModal .modal-card .info .counts svg{width:16px;height:16px;fill:#777;}
+#objectModal .modal-card .info .counts p{margin-left:2px;font-size:11px;color:#777;}
+#objectModal .modal-card .info .counts .count{display:flex;align-items:center;}
+#objectModal .pagination{display:flex;justify-content:center;margin-top:10px;}
+#closeModal{display:block;margin:10px auto 0;}
+
+#stepsModal{position:fixed;top:10%;left:50%;transform:translateX(-50%);display:none;z-index:10;}
+#stepsModal .modal-box{background:var(--color-White);border:1px solid var(--color-Borders-Main);padding:20px;width:40vw;max-height:70vh;overflow:auto;}
+#stepsList{display:flex;flex-direction:column;gap:10px;margin-bottom:10px;}
+.step-row{display:flex;flex-direction:column;gap:4px;border:1px solid var(--color-Borders-Main);padding:8px;border-radius:4px;}
+.step-row .slot-checks{display:flex;flex-wrap:wrap;gap:6px;}
+.step-row .step-header{display:flex;align-items:center;gap:8px;margin-bottom:4px;}
+#closeSteps{display:block;margin:10px auto 0;}
+#envModal{position:fixed;top:20%;left:50%;transform:translateX(-50%);display:none;z-index:10;}
+#envModal .modal-box{background:var(--color-White);border:1px solid var(--color-Borders-Main);padding:20px;}
+#closeEnv{display:block;margin:10px auto 0;}
+#varModal{position:fixed;top:20%;left:50%;transform:translateX(-50%);display:none;z-index:10;}
+#varModal .modal-box{background:var(--color-White);border:1px solid var(--color-Borders-Main);padding:20px;width:40vw;max-height:60vh;overflow:auto;}
+#varList{display:flex;flex-direction:column;gap:8px;margin-bottom:10px;}
+.var-row{display:flex;align-items:center;gap:8px;}
+.var-row label{flex:1;}
+#closeVar{display:block;margin:10px auto 0;}
+#viewModal{position:fixed;top:20%;left:50%;transform:translateX(-50%);display:none;z-index:10;}
+#viewModal .modal-box{background:var(--color-White);border:1px solid var(--color-Borders-Main);padding:20px;}
+#viewModal .modal-box label{display:flex;align-items:center;justify-content:space-between;margin-bottom:8px;}
+#viewModal .modal-box label input{margin-left:8px;}
+#closeView{display:block;margin:10px auto 0;}
+.obj-card{border:1px solid var(--color-Borders-Main);padding:5px;margin-bottom:5px;border-radius:4px;}
+.obj-card.selected{background:var(--color-Gray-20);}
+.material-list{display:flex;flex-wrap:wrap;}
+.material-list button{border:none;background:none;padding:0;margin:2px;cursor:pointer;position:relative;}
+.material-list img{width:40px;height:40px;object-fit:cover;border-radius:2px;}
+.material-list button .check{position:absolute;top:6px;right:6px;width:24px;height:24px;border-radius:999px;background:var(--color-check);display:flex;align-items:center;justify-content:center;}
+.material-list button .check img{width:14px;height:14px;filter:invert(1) brightness(2);}
+button{background:var(--color-Gray-10);border:1px solid var(--color-Borders-Main);border-radius:4px;padding:4px 8px;color:var(--color-Text-Main);transition:background .2s,color .2s;}
+button:hover{background:var(--color-Brand-Main);color:var(--color-White);}
+button.active{background:var(--color-Brand-Main);color:var(--color-White);}
+#slots{list-style:none;padding:0;margin:0;flex:1;overflow-y:auto;}
+.slot{display:flex;align-items:center;justify-content:space-between;margin-bottom:5px;cursor:pointer;padding:2px 4px;border-radius:4px;width:100%;}
+.slot.selected{background:var(--color-Gray-20);}
+.slot-actions{display:flex;gap:5px;}
+.slot-actions button{margin-left:0;}
+.action-btn{background:var(--color-White);}
+.action-btn:hover,.action-btn:active{background:var(--color-Brand-Main);color:var(--color-White);}
+#addSlotBtn{display:block;width:100%;margin-bottom:10px;}
+#envRow{display:flex;gap:5px;margin-top:auto;}
+#envRow button{flex:1;}
+#gridBtn{position:absolute;bottom:10px;right:10px;}
+#outlineBtn{position:absolute;bottom:10px;right:80px;}
+.hide-btn.active{background:var(--color-Gray-70);color:var(--color-White);}
+#versionLabel{position:fixed;top:4px;right:8px;font-size:12px;color:var(--color-Gray-60);}
+#loadingOverlay{position:fixed;inset:0;background:rgba(0,0,0,0.5);display:none;align-items:center;justify-content:center;z-index:20;}
+#loadingOverlay .loading-box{display:flex;flex-direction:column;align-items:center;text-align:center;color:var(--color-White);}
+#loadingOverlay .loading-box p{margin:0 0 8px;}
+#loadingOverlay .progress{width:200px;height:8px;background:var(--color-Gray-20);margin-top:10px;border-radius:4px;overflow:hidden;}
+#progressBar{height:100%;width:0;background:var(--color-Brand-Main);}
+
+@media (max-width:768px){
+  #container{flex-direction:column;}
+  #viewer{flex:none;height:66vh;}
+  #slotsPanel{order:2;width:100%;height:34vh;border-right:none;border-top:1px solid var(--color-Borders-Main);}
+  #objectsPanel{display:none;}
+  #slots{padding:10px;}
+  .slot-mobile summary{display:flex;justify-content:space-between;align-items:center;padding:4px;cursor:pointer;}
+  .slot-mobile summary::-webkit-details-marker{display:none;}
+  .slot-mobile{border-bottom:1px solid var(--color-Borders-Main);}
+  .slot-mobile .obj-card{margin:5px 0;}
+}

--- a/viewer/default-config.json
+++ b/viewer/default-config.json
@@ -1,0 +1,130 @@
+{
+  "version": 2,
+  "variants": {
+    "8c7dd03e-5197-4805-a46a-255817d1387e": {
+      "name": "Fireplace",
+      "steps": {
+        "0cf6024c-209d-46b8-ba8f-9af420a89707": {
+          "name": "Step 1",
+          "index": 0
+        }
+      },
+      "slots": {
+        "0999c058-f430-495b-b517-d0cf4df5c6e7": {
+          "name": "Interior",
+          "canBeEmpty": false,
+          "textButtons": false,
+          "step": "0cf6024c-209d-46b8-ba8f-9af420a89707",
+          "objects": [
+            {
+              "uuid": "1a151867-b9dc-49e7-84a6-a12a9f9288d8",
+              "position": [0, 0, 0],
+              "rotation": [0, 0, 0],
+              "scale": [1, 1, 1],
+              "colorNames": ["Matte Black", "Glossy Black", "Brick"]
+            }
+          ]
+        },
+        "a7c43ed0-9be2-4e25-b9bd-63ba56999893": {
+          "name": "Base",
+          "canBeEmpty": false,
+          "textButtons": false,
+          "step": "0cf6024c-209d-46b8-ba8f-9af420a89707",
+          "objects": [
+            {
+              "uuid": "79429d37-dc1f-45c7-9704-97fa8bafe63f",
+              "position": [0, 0, 0],
+              "rotation": [0, 0, 0],
+              "scale": [1, 1, 1],
+              "colorNames": ["Black"]
+            }
+          ]
+        },
+        "c75f9ec6-27f6-43ad-aee8-055201225fa7": {
+          "name": "Logs",
+          "canBeEmpty": false,
+          "textButtons": false,
+          "step": "0cf6024c-209d-46b8-ba8f-9af420a89707",
+          "objects": [
+            {
+              "uuid": "074a86df-cd74-41c9-a17e-e4fc867d75bc",
+              "position": [0, 0, 0],
+              "rotation": [0, 0, 0],
+              "scale": [1, 1, 1],
+              "colorNames": ["Logs 1", "Logs 2", "Logs 3"]
+            },
+            {
+              "uuid": "304fac6d-8128-48f6-bd45-4c69ce453eeb",
+              "position": [0, 0, 0],
+              "rotation": [0, 0, 0],
+              "scale": [1, 1, 1],
+              "colorNames": ["Logs 4"]
+            }
+          ]
+        },
+        "dee095f1-4f11-4722-b355-d41372f4e611": {
+          "name": "Plate",
+          "canBeEmpty": false,
+          "textButtons": false,
+          "step": "0cf6024c-209d-46b8-ba8f-9af420a89707",
+          "objects": [
+            {
+              "uuid": "c39d4813-b46f-4f74-9557-ef544dcef48f",
+              "position": [0, 0, 0],
+              "rotation": [0, 0, 0],
+              "scale": [1, 1, 1],
+              "colorNames": ["Plate 1"]
+            },
+            {
+              "uuid": "3d87ec44-e2d3-46cb-8664-d604871489be",
+              "position": [0, 0, 0],
+              "rotation": [0, 0, 0],
+              "scale": [1, 1, 1],
+              "colorNames": ["Plate 2"]
+            },
+            {
+              "uuid": "d5b1fc06-7617-46e8-9ac6-a28f26b63406",
+              "position": [0, 0, 0],
+              "rotation": [0, 0, 0],
+              "scale": [1, 1, 1],
+              "colorNames": ["Plate 3"]
+            }
+          ]
+        },
+        "1fd0260a-4236-47d5-9cb9-790ce96ff274": {
+          "name": "Glass",
+          "canBeEmpty": false,
+          "textButtons": false,
+          "step": "0cf6024c-209d-46b8-ba8f-9af420a89707",
+          "objects": [
+            {
+              "uuid": "aa2cc29f-00b9-422e-9a8c-3ee81b483538",
+              "position": [0, 0, 0],
+              "rotation": [0, 0, 0],
+              "scale": [1, 1, 1],
+              "colorNames": ["Glass"]
+            }
+          ]
+        }
+      },
+      "viewPoint": {
+        "position": [-0.045854944300355416, 1.0932244192847875, -0.1969491776390001],
+        "rotation": [0, 0, 0],
+        "left": 15,
+        "right": 30,
+        "down": 25,
+        "up": 45,
+        "maxDistance": 4,
+        "allowMovement": false,
+        "enabled": true,
+        "hidden": false
+      }
+    }
+  },
+  "environment": {
+    "uuid": "3581b9d6-68c1-470f-83bb-f82bea1b42d3",
+    "position": [0, 0, 0],
+    "rotation": [0, 0, 0],
+    "scale": [1, 1, 1]
+  }
+}

--- a/viewer/index.html
+++ b/viewer/index.html
@@ -24,7 +24,7 @@
           <p class="title">View in place</p>
           <span class="desc">Scan this QR code with your phone's camera</span>
         </div>
-        <div class="qr-code"><canvas id="qrCanvas"></canvas></div>
+        <div class="qr-code" id="qrCanvas"></div>
       </div>
     </div>
     <div id="slotPanel">
@@ -44,6 +44,7 @@
     </div>
   </div>
   <model-viewer id="ar-viewer" ar ar-modes="webxr" style="width:0;height:0;visibility:hidden"></model-viewer>
+  <script src="https://cdn.jsdelivr.net/gh/davidshimjs/qrcodejs/qrcode.min.js"></script>
   <script type="module" src="./js/viewer-main.js"></script>
 </body>
 </html>

--- a/viewer/index.html
+++ b/viewer/index.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Viewer</title>
+  <link rel="stylesheet" href="viewer.css" />
+  <script type="importmap">
+  {
+    "imports": {
+      "three": "https://unpkg.com/three@0.165.0/build/three.module.js",
+      "three/examples/jsm/": "https://unpkg.com/three@0.165.0/examples/jsm/"
+    }
+  }
+  </script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@google/model-viewer/dist/model-viewer.min.js"></script>
+</head>
+<body>
+  <div id="viewerWrapper">
+    <div id="viewerCanvas">
+      <button id="arBtn">View in place</button>
+      <div id="qrOverlay">
+        <div class="qr-text">
+          <p class="title">View in place</p>
+          <span class="desc">Scan this QR code with your phone's camera</span>
+        </div>
+        <div class="qr-code"><canvas id="qrCanvas"></canvas></div>
+      </div>
+    </div>
+    <div id="slotPanel">
+      <div id="variantBar"></div>
+      <div id="stepControls">
+        <button id="prevStep">Prev</button>
+        <span id="stepName"></span>
+        <button id="nextStep">Next</button>
+      </div>
+      <div id="slotsContainer"></div>
+    </div>
+  </div>
+  <div id="loadingOverlay" class="white">
+    <div class="loading-box">
+      <p>Loading</p>
+      <div class="progress"><div id="progressBar"></div></div>
+    </div>
+  </div>
+  <model-viewer id="ar-viewer" ar ar-modes="webxr" style="width:0;height:0;visibility:hidden"></model-viewer>
+  <script type="module" src="./js/viewer-main.js"></script>
+</body>
+</html>

--- a/viewer/index.html
+++ b/viewer/index.html
@@ -22,7 +22,7 @@
       <div id="qrOverlay">
         <div class="qr-text">
           <p class="title">View in place</p>
-          <span class="desc">Scan this QR code with your phone's camera</span>
+          <span class="desc">Scan this QR code with<br/>your phone's camera</span>
         </div>
         <div class="qr-code" id="qrCanvas"></div>
       </div>

--- a/viewer/js/ar.js
+++ b/viewer/js/ar.js
@@ -1,0 +1,158 @@
+import * as THREE from 'three';
+import { GLTFExporter } from 'three/examples/jsm/exporters/GLTFExporter.js';
+import { USDZExporter } from 'three/examples/jsm/exporters/USDZExporter.js';
+
+function fixTexture(tex) {
+  if (!tex) return null;
+  const img = tex.image;
+  if (
+    img instanceof HTMLImageElement ||
+    img instanceof HTMLCanvasElement ||
+    img instanceof ImageBitmap ||
+    img instanceof OffscreenCanvas
+  ) {
+    return tex;
+  }
+  if (img && img.data && img.width && img.height) {
+    const canvas = document.createElement('canvas');
+    canvas.width = img.width;
+    canvas.height = img.height;
+    const ctx = canvas.getContext('2d');
+    const data = img.data.buffer ? new Uint8ClampedArray(img.data.buffer) : img.data;
+    const imageData = new ImageData(data, img.width, img.height);
+    ctx.putImageData(imageData, 0, 0);
+    const ctex = new THREE.CanvasTexture(canvas);
+    ctex.flipY = tex.flipY;
+    ctex.wrapS = tex.wrapS;
+    ctex.wrapT = tex.wrapT;
+    ctex.repeat.copy(tex.repeat);
+    ctex.offset.copy(tex.offset);
+    return ctex;
+  }
+  return null;
+}
+
+// Export the current scene and launch model-viewer's AR mode.
+export async function viewInAR(scene) {
+  const exportScene = new THREE.Group();
+  scene.updateMatrixWorld(true);
+
+  // Clone all meshes with world transforms and strip extra attributes.
+  scene.traverse(obj => {
+    if (!obj.isMesh) return;
+    if (obj.userData.isEnv) return;
+
+    const toStandard = m => {
+      if (m.isMeshStandardMaterial) {
+        const mat = m.clone();
+        mat.side = THREE.FrontSide;
+        mat.envMap = null;
+        ['map', 'normalMap', 'roughnessMap', 'metalnessMap'].forEach(k => {
+          if (mat[k]) {
+            const fixed = fixTexture(mat[k]);
+            if (fixed) mat[k] = fixed; else delete mat[k];
+          }
+        });
+        return mat;
+      }
+      const params = { color: m.color };
+      if (m.map) {
+        const t = fixTexture(m.map); if (t) params.map = t;
+      }
+      if (m.normalMap) {
+        const t = fixTexture(m.normalMap); if (t) params.normalMap = t;
+      }
+      if (m.roughnessMap) {
+        const t = fixTexture(m.roughnessMap); if (t) params.roughnessMap = t;
+      }
+      if (m.metalnessMap) {
+        const t = fixTexture(m.metalnessMap); if (t) params.metalnessMap = t;
+      }
+      const mat = new THREE.MeshStandardMaterial(params);
+      mat.side = THREE.FrontSide;
+      mat.envMap = null;
+      return mat;
+    };
+
+    let baseMat;
+    if (Array.isArray(obj.material)) {
+      baseMat = obj.material.find(m => m.isMeshStandardMaterial) || obj.material[0];
+    } else {
+      baseMat = obj.material;
+    }
+    const material = toStandard(baseMat);
+
+    const geom = obj.geometry.clone();
+    geom.applyMatrix4(obj.matrixWorld);
+
+    if (!geom.attributes.normal) geom.computeVertexNormals();
+    if (!geom.attributes.uv) {
+      const count = geom.attributes.position.count;
+      geom.setAttribute('uv', new THREE.BufferAttribute(new Float32Array(count * 2), 2));
+    }
+    for (const name of Object.keys(geom.attributes)) {
+      if (name !== 'position' && name !== 'normal' && name !== 'uv') {
+        geom.deleteAttribute(name);
+      }
+    }
+    geom.morphAttributes = {};
+
+    const mesh = new THREE.Mesh(geom, material);
+    mesh.matrixAutoUpdate = false;
+    exportScene.add(mesh);
+  });
+
+  if (exportScene.children.length === 0) return;
+
+  const ua = navigator.userAgent;
+  const isIOS = /iPad|iPhone|iPod/.test(ua);
+  const isAndroid = /Android/.test(ua);
+
+  if (isIOS) {
+    try {
+      const usdzExporter = new USDZExporter();
+      const arraybuffer = await usdzExporter.parseAsync(exportScene);
+      if (arraybuffer) {
+        const usdzFile = new File([arraybuffer], 'scene.usdz', {
+          type: 'model/vnd.usdz+zip'
+        });
+        const usdzUrl = URL.createObjectURL(usdzFile);
+        const link = document.createElement('a');
+        link.setAttribute('rel', 'ar');
+        link.href = usdzUrl + '#allowsContentScaling=0';
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+        setTimeout(() => URL.revokeObjectURL(usdzUrl), 10000);
+      }
+    } catch (err) {
+      console.error('USDZ export failed', err);
+    }
+    return;
+  }
+
+  const exporter = new GLTFExporter();
+  const glbBuffer = await exporter.parseAsync(exportScene, { binary: true });
+  const glbBlob = new Blob([glbBuffer], { type: 'model/gltf-binary' });
+
+  if (isAndroid) {
+    const modelViewer = document.getElementById('ar-viewer');
+    if (!modelViewer) return;
+    const glbUrl = URL.createObjectURL(glbBlob);
+    const onLoad = () => {
+      modelViewer.removeEventListener('load', onLoad);
+      modelViewer.activateAR();
+      setTimeout(() => URL.revokeObjectURL(glbUrl), 10000);
+    };
+    modelViewer.addEventListener('load', onLoad, { once: true });
+    modelViewer.setAttribute('src', glbUrl);
+    return;
+  }
+
+  const link = document.createElement('a');
+  link.href = URL.createObjectURL(glbBlob);
+  link.download = 'scene.glb';
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+}

--- a/viewer/js/viewer-api.js
+++ b/viewer/js/viewer-api.js
@@ -1,0 +1,14 @@
+export async function fetchObjectDetails(uuid){
+  try{
+    const res = await fetch('https://api.vizbl.us/obj/Fetch',{ 
+      method:'POST',
+      headers:{'Content-Type':'application/json'},
+      body:JSON.stringify({uuid})
+    });
+    if(!res.ok) return null;
+    return await res.json();
+  }catch(e){
+    console.error('fetchObjectDetails',e);
+    return null;
+  }
+}

--- a/viewer/js/viewer-main.js
+++ b/viewer/js/viewer-main.js
@@ -406,17 +406,36 @@ arBtn.addEventListener('click', async () => {
 function encodeConfig(){
   let str='';
   state.slots.forEach(slot=>{
-    const idx=slot.selectedIndex<0?0:slot.selectedIndex;
-    str+=String.fromCharCode(65+idx);
+    let sel=0, idx=0;
+    if(slot.canBeEmpty){
+      if(slot.selectedIndex<0) sel=0;
+      else idx=1;
+    }
+    slot.objects.forEach((obj,oIdx)=>{
+      obj.materials.forEach((mat,mIdx)=>{
+        if(slot.selectedIndex===oIdx && (obj.selectedMaterial||0)===mIdx) sel=idx;
+        idx++;
+      });
+    });
+    str+=String.fromCharCode(65+sel);
   });
   return str;
 }
 
 function applyEncodedConfig(str){
   for(let i=0;i<state.slots.length && i<str.length;i++){
-    const idx=str.charCodeAt(i)-65;
-    if(idx>=0 && idx<state.slots[i].objects.length){
-      state.slots[i].selectedIndex=idx;
+    let idx=str.charCodeAt(i)-65;
+    const slot=state.slots[i];
+    if(slot.canBeEmpty){
+      if(idx===0){ slot.selectedIndex=-1; continue; }
+      idx--;
+    }
+    outer: for(let o=0;o<slot.objects.length;o++){
+      const obj=slot.objects[o];
+      for(let m=0;m<obj.materials.length;m++){
+        if(idx===0){ slot.selectedIndex=o; obj.selectedMaterial=m; break outer; }
+        idx--;
+      }
     }
   }
 }

--- a/viewer/js/viewer-main.js
+++ b/viewer/js/viewer-main.js
@@ -1,0 +1,439 @@
+import * as THREE from 'three';
+import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
+import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
+import { RGBELoader } from 'three/examples/jsm/loaders/RGBELoader.js';
+import QRCode from 'https://cdn.jsdelivr.net/npm/qrcode@1.5.4/build/qrcode.min.js';
+import { viewInAR } from './ar.js';
+import { ViewerState } from './viewer-state.js';
+import { renderSlots, renderVariants } from './viewer-ui.js';
+import { fetchObjectDetails } from './viewer-api.js';
+
+const container = document.getElementById('viewerCanvas');
+const slotPanel = document.getElementById('slotPanel');
+const variantBar = document.getElementById('variantBar');
+const slotsContainer = document.getElementById('slotsContainer');
+const arBtn = document.getElementById('arBtn');
+const qrOverlay = document.getElementById('qrOverlay');
+const qrCanvas = document.getElementById('qrCanvas');
+const stepNameEl = document.getElementById('stepName');
+const prevStepBtn = document.getElementById('prevStep');
+const nextStepBtn = document.getElementById('nextStep');
+const stepControls = document.getElementById('stepControls');
+
+const scene = new THREE.Scene();
+const camera = new THREE.PerspectiveCamera(60, 1, 0.1, 1000);
+const renderer = new THREE.WebGLRenderer({ antialias: true });
+renderer.setPixelRatio(window.devicePixelRatio);
+renderer.outputEncoding = THREE.sRGBEncoding;
+renderer.toneMapping = THREE.LinearToneMapping;
+renderer.physicallyCorrectLights = true;
+renderer.setClearColor(0xffffff, 1);
+container.appendChild(renderer.domElement);
+const controls = new OrbitControls(camera, renderer.domElement);
+camera.position.set(0, 1, 3);
+controls.update();
+const defaultCamPos = camera.position.clone();
+const defaultTarget = controls.target.clone();
+
+const pmrem = new THREE.PMREMGenerator(renderer);
+  new RGBELoader().load(
+    'https://vizbl.com/hdr/neutral.hdr',
+    (hdr) => {
+      const envMap = pmrem.fromEquirectangular(hdr).texture;
+    scene.environment = envMap;
+    scene.background = new THREE.Color(0xffffff);
+      hdr.dispose();
+      pmrem.dispose();
+    }
+  );
+
+const ambient = new THREE.AmbientLight(0xffffff, 0.3);
+scene.add(ambient);
+const dirLight = new THREE.DirectionalLight(0xffffff, 2.5);
+dirLight.position.set(5, 10, 7.5);
+scene.add(dirLight);
+
+const isMobile=/iPhone|iPad|iPod|Android/i.test(navigator.userAgent);
+
+function resize() {
+  const w = container.clientWidth;
+  const h = container.clientHeight;
+  renderer.setSize(w, h);
+  camera.aspect = w / h;
+  camera.updateProjectionMatrix();
+}
+window.addEventListener('resize', resize);
+resize();
+
+function animate() {
+  requestAnimationFrame(animate);
+  renderer.render(scene, camera);
+}
+animate();
+
+const state = new ViewerState();
+const loader = new GLTFLoader();
+const raycaster = new THREE.Raycaster();
+const pointer = new THREE.Vector2();
+let pointerDown = null;
+let pointerMoved = false;
+let envMesh = null;
+function applyViewPoint(){
+  const vp = state.viewPoint;
+  if(!vp.enabled){ resetViewPoint(); return; }
+  controls.target.set(vp.position[0], vp.position[1], vp.position[2]);
+  const offset = new THREE.Vector3(0,1,3);
+  const euler = new THREE.Euler(
+    THREE.MathUtils.degToRad(vp.rotation[0]),
+    THREE.MathUtils.degToRad(vp.rotation[1]),
+    THREE.MathUtils.degToRad(vp.rotation[2])
+  );
+  offset.applyEuler(euler);
+  camera.position.set(vp.position[0]+offset.x, vp.position[1]+offset.y, vp.position[2]+offset.z);
+  const sph = new THREE.Spherical().setFromVector3(offset);
+  const basePolar = sph.phi;
+  const baseAzimuth = sph.theta;
+  if(vp.up>0) {
+    controls.minPolarAngle = Math.max(0, basePolar - THREE.MathUtils.degToRad(vp.up));
+  } else {
+    controls.minPolarAngle = 0;
+  }
+  if(vp.down>0) {
+    controls.maxPolarAngle = Math.min(Math.PI, basePolar + THREE.MathUtils.degToRad(vp.down));
+  } else {
+    controls.maxPolarAngle = Math.PI;
+  }
+  if(vp.left>0) {
+    controls.minAzimuthAngle = baseAzimuth - THREE.MathUtils.degToRad(vp.left);
+  } else {
+    controls.minAzimuthAngle = -Infinity;
+  }
+  if(vp.right>0) {
+    controls.maxAzimuthAngle = baseAzimuth + THREE.MathUtils.degToRad(vp.right);
+  } else {
+    controls.maxAzimuthAngle = Infinity;
+  }
+  controls.maxDistance = vp.maxDistance>0?vp.maxDistance:Infinity;
+  controls.enablePan = vp.allowMovement;
+  controls.update();
+}
+
+function resetViewPoint(){
+  controls.target.copy(defaultTarget);
+  camera.position.copy(defaultCamPos);
+  controls.minPolarAngle=0;
+  controls.maxPolarAngle=Math.PI;
+  controls.minAzimuthAngle=-Infinity;
+  controls.maxAzimuthAngle=Infinity;
+  controls.maxDistance=Infinity;
+  controls.enablePan=true;
+  controls.update();
+}
+
+function renderUI(){
+  renderVariants(variantBar, state, selectVariant);
+  if(state.currentStep){
+    const name = state.currentStep.name || `Step ${state.currentStepIndex + 1}`;
+    stepNameEl.textContent = name;
+  }else{
+    stepNameEl.textContent = '';
+  }
+  stepControls.style.display = state.steps.length>1 ? 'flex' : 'none';
+  renderSlots(slotsContainer, state, selectObject);
+}
+
+function showLoading(r, initial = false, message = 'Loading', showBar = true) {
+  const overlay = document.getElementById('loadingOverlay');
+  const bar = document.getElementById('progressBar');
+  const progressWrap = overlay.querySelector('.progress');
+  overlay.querySelector('p').textContent = message;
+  if (initial) overlay.classList.add('white');
+  overlay.style.display = 'flex';
+  if (showBar) {
+    progressWrap.style.display = 'block';
+    bar.style.width = Math.floor(r * 100) + '%';
+  } else {
+    progressWrap.style.display = 'none';
+  }
+}
+function hideLoading() {
+  const overlay = document.getElementById('loadingOverlay');
+  overlay.style.display = 'none';
+  overlay.classList.remove('white');
+  const progressWrap = overlay.querySelector('.progress');
+  progressWrap.style.display = 'block';
+  document.getElementById('progressBar').style.width = '0';
+}
+
+async function loadMesh(obj, overlay = false, progressCb) {
+  if (obj.mesh) return obj.mesh;
+  const mat = obj.materials[obj.selectedMaterial || 0];
+  const url = mat?.native?.glbUrl;
+  if (!url) return null;
+  return await new Promise((resolve) => {
+    if (overlay) showLoading(0);
+    loader.load(
+      url,
+      (gltf) => {
+        obj.mesh = gltf.scene;
+        resolve(obj.mesh);
+      },
+      (evt) => {
+        if (progressCb) {
+          const ratio = evt.total ? evt.loaded / evt.total : 0;
+          progressCb(ratio);
+        }
+        if (overlay && evt.total) showLoading(evt.loaded / evt.total);
+      },
+      (err) => {
+        console.error(err);
+        resolve(null);
+      }
+    );
+  });
+}
+
+async function selectObject(slotIdx, objIdx, matIdx) {
+  const slot = state.slots[slotIdx];
+  const previousMesh = slot.currentMesh;
+  const previousIndex = slot.selectedIndex;
+  slot.selectedIndex = objIdx;
+
+  if (objIdx === -1) {
+    if (previousMesh) scene.remove(previousMesh);
+    slot.currentMesh = null;
+    renderUI();
+    updateShare();
+    hideLoading();
+    return;
+  }
+
+  const obj = slot.objects[objIdx];
+  if (typeof matIdx === 'number' && obj.selectedMaterial !== matIdx) {
+    obj.selectedMaterial = matIdx;
+    obj.mesh = null;
+  }
+
+  const mesh = await loadMesh(obj, !obj.mesh);
+  if (!mesh) {
+    slot.selectedIndex = previousIndex;
+    renderUI();
+    hideLoading();
+    return;
+  }
+
+  const inst = mesh.clone();
+  inst.position.fromArray(obj.transform.position);
+  inst.rotation.set(
+    ...obj.transform.rotation.map((r) => THREE.MathUtils.degToRad(r))
+  );
+  inst.scale.fromArray(obj.transform.scale);
+  inst.userData.slotIdx = slotIdx;
+  inst.userData.objIdx = objIdx;
+  slot.currentMesh = inst;
+  scene.add(inst);
+  if (previousMesh) scene.remove(previousMesh);
+  renderUI();
+  updateShare();
+  hideLoading();
+}
+
+async function loadAll(){
+  if(envMesh){
+    scene.remove(envMesh); envMesh=null;
+  }
+  state.slots.forEach(s=>{
+    if(s.currentMesh){ scene.remove(s.currentMesh); s.currentMesh=null; }
+  });
+
+  const slotsToLoad = state.slots.filter(s=>s.selectedIndex>=0);
+  const tasks = [];
+  if(state.environment){
+    const mat=state.environment.materials[state.environment.selectedMaterial];
+    const url=mat?.native?.glbUrl;
+    if(url) tasks.push({type:'env', obj:state.environment, url});
+  }
+  for(const slot of slotsToLoad){
+    const obj = slot.objects[slot.selectedIndex];
+    const mat = obj.materials[obj.selectedMaterial || 0];
+    const url = mat?.native?.glbUrl;
+    if(url) tasks.push({type:'slot', slot, obj, url});
+  }
+
+  const totalTasks = tasks.length || 1;
+  let completed = 0;
+  showLoading(0, true);
+
+  for(const t of tasks){
+    if(!t.obj.mesh){
+      await loadMesh(t.obj,false,(r)=>{
+        showLoading((completed + r)/totalTasks);
+      });
+    }
+    completed++;
+    showLoading(completed/totalTasks);
+    
+    if(t.type==='env'){
+      envMesh = t.obj.mesh.clone();
+      envMesh.userData.isEnv=true;
+      envMesh.traverse(ch=>{
+        ch.userData.isEnv=true;
+        if(ch.isMesh){
+          ch.castShadow=false; ch.receiveShadow=false;
+          const m=ch.material;
+          ch.material=new THREE.MeshBasicMaterial({
+            map:m.map, aoMap:m.aoMap, aoMapIntensity:m.aoMapIntensity,
+            color:m.color?.clone(), transparent:m.transparent, opacity:m.opacity, side:m.side
+          });
+        }
+      });
+      envMesh.position.fromArray(t.obj.transform.position);
+      envMesh.rotation.set(...t.obj.transform.rotation.map(r=>THREE.MathUtils.degToRad(r)));
+      envMesh.scale.fromArray(t.obj.transform.scale);
+      scene.add(envMesh);
+      envMesh.updateWorldMatrix(true, true);
+    }else{
+      const inst = t.obj.mesh.clone();
+      inst.position.fromArray(t.obj.transform.position);
+      inst.rotation.set(...t.obj.transform.rotation.map(r=>THREE.MathUtils.degToRad(r)));
+      inst.scale.fromArray(t.obj.transform.scale);
+      inst.userData.slotIdx = state.slots.indexOf(t.slot);
+      inst.userData.objIdx = t.slot.selectedIndex;
+      t.slot.currentMesh = inst;
+      scene.add(inst);
+    }
+  }
+  showLoading(1);
+  renderUI();
+  updateShare();
+}
+
+async function selectVariant(idx){
+  if(idx===state.currentVariantIndex) return;
+  showLoading(0, true);
+  state.slots.forEach(s=>{
+    if(s.currentMesh){scene.remove(s.currentMesh); s.currentMesh=null;}
+  });
+  state.setVariant(idx);
+  await loadAll();
+  if(state.viewPoint.enabled) applyViewPoint(); else resetViewPoint();
+  updateShare();
+  hideLoading();
+}
+
+function handleSceneClick(event) {
+  const rect = renderer.domElement.getBoundingClientRect();
+  pointer.x = ((event.clientX - rect.left) / rect.width) * 2 - 1;
+  pointer.y = -((event.clientY - rect.top) / rect.height) * 2 + 1;
+  raycaster.setFromCamera(pointer, camera);
+  const objs = state.slots.map((s) => s.currentMesh).filter(Boolean);
+  const intersect = raycaster.intersectObjects(objs, true)[0];
+  if (!intersect) return;
+  let obj = intersect.object;
+  while (obj && obj.userData.slotIdx === undefined) obj = obj.parent;
+  if (!obj) return;
+  const slotIdx = obj.userData.slotIdx;
+  const objIdx = obj.userData.objIdx;
+  const slot = state.slots[slotIdx];
+  slot.selectedIndex = objIdx;
+  slot.open = true;
+    renderUI();
+    const slotEl = slotsContainer.children[state.slots.indexOf(slot)];
+  if (slotEl) {
+    slotEl.open = true;
+    slotEl.scrollIntoView({ block: 'nearest' });
+  }
+}
+
+renderer.domElement.addEventListener('pointerdown', (e) => {
+  if (e.button !== 0) return;
+  pointerDown = { x: e.clientX, y: e.clientY };
+  pointerMoved = false;
+});
+
+renderer.domElement.addEventListener('pointermove', (e) => {
+  if (!pointerDown) return;
+  if (Math.abs(e.clientX - pointerDown.x) > 5 || Math.abs(e.clientY - pointerDown.y) > 5) {
+    pointerMoved = true;
+  }
+});
+
+renderer.domElement.addEventListener('pointerup', (e) => {
+  if (e.button !== 0) return;
+  if (!pointerMoved) handleSceneClick(e);
+  pointerDown = null;
+});
+
+prevStepBtn.addEventListener('click',()=>{
+  state.currentStepIndex = (state.currentStepIndex - 1 + state.steps.length) % state.steps.length;
+  renderUI();
+  updateShare();
+});
+nextStepBtn.addEventListener('click',()=>{
+  state.currentStepIndex = (state.currentStepIndex + 1) % state.steps.length;
+  renderUI();
+  updateShare();
+});
+
+arBtn.addEventListener('click', async () => {
+  showLoading(0, false, 'Prepare AR scene', false);
+  await viewInAR(scene);
+  hideLoading();
+});
+
+(async () => {
+  showLoading(0, true);
+  try {
+    const res = await fetch('default-config.json');
+    const data = await res.json();
+    await state.loadConfig(data, fetchObjectDetails);
+    const params=new URLSearchParams(location.search);
+    const cfg=params.get('cfg');
+    if(cfg) applyEncodedConfig(cfg);
+    await loadAll();
+    if (state.viewPoint.enabled) {
+      applyViewPoint();
+    } else {
+      resetViewPoint();
+    }
+    updateShare();
+    hideLoading();
+  } catch (err) {
+    console.error('Default config load failed', err);
+    hideLoading();
+  }
+})();
+
+function encodeConfig(){
+  let str='';
+  state.slots.forEach(slot=>{
+    const idx=slot.selectedIndex<0?0:slot.selectedIndex;
+    str+=String.fromCharCode(65+idx);
+  });
+  return str;
+}
+
+function applyEncodedConfig(str){
+  for(let i=0;i<state.slots.length && i<str.length;i++){
+    const idx=str.charCodeAt(i)-65;
+    if(idx>=0 && idx<state.slots[i].objects.length){
+      state.slots[i].selectedIndex=idx;
+    }
+  }
+}
+
+function updateShare(){
+  if(isMobile){
+    arBtn.style.display='block';
+    qrOverlay.style.display='none';
+    return;
+  }
+  arBtn.style.display='none';
+  qrOverlay.style.display='inline-flex';
+  const url=location.origin+location.pathname+ '?cfg='+encodeConfig();
+  const ctx=qrCanvas.getContext('2d');
+  ctx.clearRect(0,0,qrCanvas.width,qrCanvas.height);
+  QRCode.toCanvas(qrCanvas,url,{width:96},err=>{
+    if(err) console.error('QR error',err);
+  });
+}

--- a/viewer/js/viewer-main.js
+++ b/viewer/js/viewer-main.js
@@ -2,7 +2,6 @@ import * as THREE from 'three';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
 import { RGBELoader } from 'three/examples/jsm/loaders/RGBELoader.js';
-import QRCode from 'https://cdn.jsdelivr.net/npm/qrcode@1.5.4/build/qrcode.min.js';
 import { viewInAR } from './ar.js';
 import { ViewerState } from './viewer-state.js';
 import { renderSlots, renderVariants } from './viewer-ui.js';
@@ -430,10 +429,14 @@ function updateShare(){
   }
   arBtn.style.display='none';
   qrOverlay.style.display='inline-flex';
-  const url=location.origin+location.pathname+ '?cfg='+encodeConfig();
-  const ctx=qrCanvas.getContext('2d');
-  ctx.clearRect(0,0,qrCanvas.width,qrCanvas.height);
-  QRCode.toCanvas(qrCanvas,url,{width:96},err=>{
-    if(err) console.error('QR error',err);
+  const url = location.origin + location.pathname + '?cfg=' + encodeConfig();
+  qrCanvas.innerHTML = '';
+  new QRCode(qrCanvas, {
+    text: url,
+    width: 96,
+    height: 96,
+    colorDark: '#000000',
+    colorLight: '#ffffff',
+    correctLevel: QRCode.CorrectLevel.H
   });
 }

--- a/viewer/js/viewer-state.js
+++ b/viewer/js/viewer-state.js
@@ -1,0 +1,130 @@
+export class ViewerState {
+  constructor() {
+    this.variants = [];
+    this.currentVariantIndex = 0;
+    this.slots = [];
+    this.steps = [];
+    this.environment = null;
+    this.currentStepIndex = 0;
+    this.viewPoint = { position:[0,0,0], rotation:[0,0,0], left:0, right:0, down:0, up:0, maxDistance:0, allowMovement:false };
+  }
+
+  async _buildVariant(src, fetchDetails, fallbackName) {
+    let steps;
+    if (Array.isArray(src.steps)) {
+      steps = src.steps.map((s, i) => ({
+        id: s.id || crypto.randomUUID(),
+        name: s.name || `Step ${i + 1}`,
+        index: s.index ?? i
+      }));
+    } else {
+      steps = Object.entries(src.steps || {}).map(([id, s], i) => ({
+        id,
+        name: s.name || `Step ${i + 1}`,
+        index: s.index ?? i
+      }));
+    }
+    if (!steps.length) {
+      const def = { id: crypto.randomUUID(), name: 'Step 1', index: 0 };
+      steps = [def];
+    }
+    steps.sort((a, b) => a.index - b.index);
+    const defaultStepId = steps[0].id;
+
+    const slots = [];
+    for (const [id, slotData] of Object.entries(src.slots || {})) {
+      const slot = {
+        id,
+        name: slotData.name,
+        canBeEmpty: slotData.canBeEmpty,
+        textButtons: slotData.textButtons || false,
+        objects: [],
+        selectedIndex: slotData.canBeEmpty ? -1 : 0,
+        open: false,
+        currentMesh: null,
+        stepId: slotData.step || slotData.stepId || defaultStepId
+      };
+      for (const obj of slotData.objects || []) {
+        const details = await fetchDetails(obj.uuid);
+        if (!details) continue;
+        slot.objects.push({
+          uuid: obj.uuid,
+          name: details.name,
+          materials: details.materials || [],
+          selectedMaterial: 0,
+          colorNames: obj.colorNames || obj.variationNames || (details.materials || []).map(m => m.name),
+          transform: {
+            position: obj.position || [0, 0, 0],
+            rotation: obj.rotation || [0, 0, 0],
+            scale: obj.scale || [1, 1, 1]
+          },
+          mesh: null
+        });
+      }
+      slots.push(slot);
+    }
+    const viewPoint = {
+      position: src.viewPoint?.position || [0,0,0],
+      rotation: src.viewPoint?.rotation || [0,0,0],
+      left: src.viewPoint?.left || 0,
+      right: src.viewPoint?.right || 0,
+      down: src.viewPoint?.down || 0,
+      up: src.viewPoint?.up || 0,
+      maxDistance: src.viewPoint?.maxDistance || 0,
+      allowMovement: !!src.viewPoint?.allowMovement,
+      enabled: !!src.viewPoint?.enabled
+    };
+    return { id: src.id || crypto.randomUUID(), name: src.name || fallbackName, steps, slots, viewPoint };
+  }
+
+  async loadConfig(data, fetchDetails) {
+    this.variants = [];
+    this.environment = null;
+    if (data.variants) {
+      let idx = 1;
+      for (const [id, v] of Object.entries(data.variants)) {
+        const variant = await this._buildVariant({ ...v, id }, fetchDetails, `Variant ${idx++}`);
+        this.variants.push(variant);
+      }
+    } else {
+      const variant = await this._buildVariant(data, fetchDetails, 'Variant 1');
+      this.variants.push(variant);
+    }
+    this.setVariant(0);
+    if (data.environment) {
+      const det = await fetchDetails(data.environment.uuid);
+      if (det) {
+        this.environment = {
+          uuid: data.environment.uuid,
+          materials: det.materials || [],
+          selectedMaterial: 0,
+          transform: {
+            position: data.environment.position || [0, 0, 0],
+            rotation: data.environment.rotation || [0, 0, 0],
+            scale: data.environment.scale || [1, 1, 1]
+          },
+          mesh: null
+        };
+      }
+    }
+    this.viewPoint = { ...this.variants[0].viewPoint };
+  }
+
+  setVariant(index) {
+    this.currentVariantIndex = index;
+    const v = this.variants[index];
+    this.steps = v.steps.map(s => ({ ...s }));
+    this.slots = v.slots.map(s => ({
+      ...s,
+      open: s.open || false,
+      currentMesh: null,
+      objects: s.objects.map(o => ({ ...o, mesh: null }))
+    }));
+    this.currentStepIndex = 0;
+    this.viewPoint = { ...v.viewPoint };
+  }
+
+  get currentStep() {
+    return this.steps[this.currentStepIndex];
+  }
+}

--- a/viewer/js/viewer-ui.js
+++ b/viewer/js/viewer-ui.js
@@ -1,0 +1,144 @@
+function fitButtonText(btn){
+  const base=14;
+  btn.style.fontSize=base+'px';
+  const max=btn.clientWidth*0.85;
+  if(!max) return; // skip when button has no layout yet
+  const canvas=fitButtonText._c||(fitButtonText._c=document.createElement('canvas'));
+  const ctx=canvas.getContext('2d');
+  const style=getComputedStyle(btn);
+  ctx.font=`${style.fontWeight} ${base}px ${style.fontFamily}`;
+  const w=ctx.measureText(btn.textContent).width;
+  if(w>max){
+    btn.style.fontSize=Math.floor(base*max/w)+'px';
+  }
+}
+
+export function renderVariants(container, state, onSelect){
+  container.innerHTML='';
+  if(state.variants.length<=1){
+    container.style.display='none';
+    return;
+  }
+  container.style.display='grid';
+  state.variants.forEach((v,idx)=>{
+    const btn=document.createElement('button');
+    btn.className='variant-btn';
+    btn.textContent=v.name;
+    if(state.currentVariantIndex===idx) btn.classList.add('selected');
+    btn.addEventListener('click',()=>onSelect(idx));
+    container.appendChild(btn);
+    fitButtonText(btn);
+  });
+}
+
+export function renderSlots(container, state, onSelect){
+  container.innerHTML='';
+  const stepId = state.currentStep?.id;
+  state.slots
+    .filter(s=>String(s.stepId)===String(stepId))
+    .filter(s=>{
+      if(s.canBeEmpty) return true;
+      if(s.objects.length>1) return true;
+      if(s.objects.length===1){
+        const obj=s.objects[0];
+        return obj.materials && obj.materials.length>1;
+      }
+      return false;
+    })
+    .forEach((slot)=>{
+    const slotIndex = state.slots.indexOf(slot);
+    const wrap = document.createElement('div');
+    wrap.className='slot-section';
+    const title = document.createElement('div');
+    title.className='slot-name';
+    title.textContent = slot.name;
+    wrap.appendChild(title);
+    const list = document.createElement('div');
+    list.className = 'object-list ' + (slot.textButtons ? 'text-mode' : 'thumb-mode');
+    if(slot.canBeEmpty){
+      if(slot.textButtons){
+        const btn=document.createElement('button');
+        btn.className='variant-btn text-option';
+        btn.textContent='None';
+        if(slot.selectedIndex===-1) btn.classList.add('selected');
+        btn.setAttribute('aria-pressed', slot.selectedIndex===-1);
+        btn.addEventListener('click',()=>onSelect(slotIndex,-1,0));
+        list.appendChild(btn);
+        fitButtonText(btn);
+      }else{
+        const none=document.createElement('button');
+        none.className='object-item';
+        none.type='button';
+        if(slot.selectedIndex===-1) none.classList.add('selected');
+        none.setAttribute('aria-pressed', slot.selectedIndex===-1);
+        const thumb=document.createElement('div');
+        thumb.className='thumb';
+        const img=document.createElement('img');
+        img.src='https://cdn.jsdelivr.net/npm/lucide-static@0.452.0/icons/x.svg';
+        img.alt='None';
+        thumb.appendChild(img);
+        if(slot.selectedIndex===-1){
+          const check=document.createElement('span');
+          check.className='check';
+          const chkImg=document.createElement('img');
+          chkImg.src='https://cdn.jsdelivr.net/npm/lucide-static@0.452.0/icons/check.svg';
+          check.appendChild(chkImg);
+          thumb.appendChild(check);
+        }
+        none.appendChild(thumb);
+        const label=document.createElement('div');
+        label.className='label muted';
+        label.textContent='None';
+        none.appendChild(label);
+        none.addEventListener('click',()=>onSelect(slotIndex,-1,0));
+        list.appendChild(none);
+      }
+    }
+    slot.objects.forEach((obj,oIdx)=>{
+      obj.materials.forEach((mat,mIdx)=>{
+        if(slot.textButtons){
+          const btn=document.createElement('button');
+          btn.className='variant-btn text-option';
+          const selected = slot.selectedIndex===oIdx && obj.selectedMaterial===mIdx;
+          if(selected) btn.classList.add('selected');
+          btn.setAttribute('aria-pressed', selected);
+          btn.textContent = obj.colorNames?.[mIdx] || mat.name;
+          btn.addEventListener('click',()=>onSelect(slotIndex,oIdx,mIdx));
+          list.appendChild(btn);
+          fitButtonText(btn);
+        }else{
+          const item=document.createElement('button');
+          item.className='object-item';
+          item.type='button';
+          const selected = slot.selectedIndex===oIdx && obj.selectedMaterial===mIdx;
+          if(selected) item.classList.add('selected');
+          item.setAttribute('aria-pressed', selected);
+          const thumb=document.createElement('div');
+          thumb.className='thumb';
+          const prev=mat.previews?.[0];
+          const img=document.createElement('img');
+          img.src=prev?.subRes?.small||prev?.url||'';
+          img.alt=mat.name;
+          thumb.appendChild(img);
+          if(selected){
+            const check=document.createElement('span');
+            check.className='check';
+            const chkImg=document.createElement('img');
+            chkImg.src='https://cdn.jsdelivr.net/npm/lucide-static@0.452.0/icons/check.svg';
+            check.appendChild(chkImg);
+            thumb.appendChild(check);
+          }
+          item.appendChild(thumb);
+          const label=document.createElement('div');
+          label.className='label';
+          label.textContent=mat.name;
+          item.appendChild(label);
+          item.addEventListener('click',()=>onSelect(slotIndex,oIdx,mIdx));
+          list.appendChild(item);
+        }
+      });
+    });
+    wrap.appendChild(list);
+    container.appendChild(wrap);
+  });
+}

--- a/viewer/viewer.css
+++ b/viewer/viewer.css
@@ -1,0 +1,281 @@
+:root {
+  --color-text-main: #111827;
+  --color-text-muted: #6B7280;
+  --color-border: #E5E7EB;
+  --color-black: #111111;
+  --color-check: #22C55E;
+}
+
+html,body {
+  margin:0;
+  height:100%;
+  overflow:hidden;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  color:var(--color-text-main);
+}
+
+#viewerWrapper {
+  display:flex;
+  height:100%;
+}
+
+#viewerCanvas {
+  flex:4;
+  position:relative;
+}
+
+#slotPanel {
+  flex:1;
+  overflow-y:auto;
+  background:#fff;
+  padding:16px;
+  box-sizing:border-box;
+}
+
+#stepControls{
+  display:flex;
+  justify-content:center;
+  align-items:center;
+  gap:8px;
+  margin-bottom:10px;
+}
+
+@media(max-width:768px){
+  #viewerWrapper {flex-direction:column;}
+  #viewerCanvas {height:66.666%;flex:none;}
+  #slotPanel {height:33.333%;width:100%;flex:none;}
+  .object-list.thumb-mode {grid-template-columns:repeat(2,minmax(0,1fr));}
+  .object-list.text-mode {grid-template-columns:repeat(2,minmax(0,1fr));}
+  #variantBar {grid-template-columns:repeat(2,minmax(0,1fr));}
+}
+
+canvas {display:block;}
+
+#arBtn{
+  position:absolute;
+  bottom:16px;
+  right:16px;
+  background:#fff;
+  border:1px solid var(--color-border);
+  border-radius:10px;
+  padding:12px 20px;
+  color:var(--color-text-main);
+  font-weight:500;
+  transition:background .2s,color .2s;
+}
+#arBtn:hover{
+  background:var(--color-black);
+  color:#fff;
+  border-color:var(--color-black);
+}
+
+button {
+  background:#fff;
+  border:1px solid var(--color-border);
+  border-radius:10px;
+  padding:12px;
+  color:var(--color-text-main);
+  font-weight:500;
+  transition:background .2s,color .2s;
+}
+
+#qrOverlay{
+  position:absolute;
+  bottom:16px;
+  left:16px;
+  background:#fff;
+  border:1px solid var(--color-border);
+  border-radius:8px;
+  padding:16px 24px;
+  display:none;
+  gap:8px;
+  justify-content:space-between;
+  align-items:center;
+  max-width:360px;
+  width:auto;
+}
+#qrOverlay .title{font-size:16px;font-weight:600;}
+#qrOverlay .desc{font-size:14px;line-height:22px;color:var(--color-text-muted);font-weight:500;}
+#qrOverlay .qr-code{max-width:96px;width:100%;}
+
+/* slot list */
+.slot-section{
+  border-bottom:1px solid var(--color-border);
+  padding-bottom:24px;
+  margin-bottom:24px;
+}
+.slot-section:last-child{
+  border-bottom:none;
+  margin-bottom:0;
+  padding-bottom:0;
+}
+.slot-name{
+  font-size:16px;
+  font-weight:700;
+  letter-spacing:0.04em;
+  text-transform:uppercase;
+  margin:24px 0 12px;
+  text-align:left;
+}
+.slot-section:first-child .slot-name{margin-top:0;}
+.object-list {
+  display:grid;
+  gap:12px;
+  padding:8px 0;
+}
+.object-list.thumb-mode {
+  grid-template-columns:repeat(3,1fr);
+}
+.object-list.text-mode {
+  grid-template-columns:repeat(2,1fr);
+}
+@media(min-width:768px){
+  .object-list{gap:16px;}
+}
+.object-item {
+  width:100%;
+  text-align:center;
+  cursor:pointer;
+  display:flex;
+  flex-direction:column;
+  align-items:center;
+  gap:8px;
+  background:none;
+  border:none;
+  padding:0;
+}
+.object-item .thumb {
+  position:relative;
+  width:100%;
+  aspect-ratio:4/3;
+  background:#fff;
+  border:none;
+  border-radius:12px;
+  padding:0;
+  box-sizing:border-box;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  overflow:hidden;
+}
+.object-item .thumb img {
+  width:100%;
+  height:100%;
+  object-fit:cover;
+}
+.object-item:hover .thumb{
+  box-shadow:0 0 0 2px rgba(0,0,0,0.04) inset;
+}
+.object-item .check {
+  position:absolute;
+  top:6px;
+  right:6px;
+  width:24px;
+  height:24px;
+  border-radius:999px;
+  background:var(--color-check);
+  display:flex;
+  align-items:center;
+  justify-content:center;
+}
+.object-item .check img {
+  width:14px;
+  height:14px;
+  filter:invert(1) brightness(2);
+}
+.object-item .label {
+  font-size:13px;
+  font-weight:500;
+  line-height:1.2;
+  white-space:normal;
+  word-break:break-word;
+  text-align:center;
+  display:-webkit-box;
+  -webkit-box-orient:vertical;
+  -webkit-line-clamp:2;
+  overflow:hidden;
+  text-overflow:ellipsis;
+  color:var(--color-text-main);
+}
+.object-item .label.muted {
+  color:var(--color-text-muted);
+  font-weight:400;
+}
+
+.variant-btn{
+  border:1px solid var(--color-border);
+  border-radius:10px;
+  background:#fff;
+  cursor:pointer;
+  padding:12px;
+  font-size:14px;
+  color:var(--color-text-main);
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  text-align:center;
+}
+.variant-btn.text-option{
+  width:100%;
+  padding:11px 8px;
+  white-space:normal;
+  word-break:break-word;
+  line-height:1.2;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  text-align:center;
+  overflow:hidden;
+}
+.variant-btn.selected{
+  background:var(--color-black);
+  color:#fff;
+  border-color:var(--color-black);
+}
+
+#variantBar{
+  display:grid;
+  grid-template-columns:repeat(2,minmax(0,1fr));
+  gap:4px;
+  margin-bottom:8px;
+  padding:0 4px;
+}
+
+
+/* loading overlay */
+#loadingOverlay {
+  position:fixed;
+  inset:0;
+  background:rgba(0,0,0,0.5);
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  z-index:100;
+  color:#fff;
+}
+#loadingOverlay .loading-box {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+}
+#loadingOverlay p {
+  margin: 0 0 8px;
+}
+#loadingOverlay.white {
+  background:#fff;
+  color:#000;
+}
+#loadingOverlay .progress {
+  width:200px;
+  height:8px;
+  background:var(--color-border);
+  margin-top:10px;
+  border-radius:4px;
+  overflow:hidden;
+}
+#progressBar {
+  height:100%;
+  width:0;
+  background:var(--color-black);
+}


### PR DESCRIPTION
## Summary
- load a bundled default configuration when the viewer boots
- keep the environment visible during AR export and strip environment maps to avoid texture errors
- convert incompatible textures to CanvasTexture so AR exports retain material maps
- download GLB on desktop when triggering AR
- simplify AR activation by delegating to model-viewer and exporting USDZ for iOS
- enable AR mode on mobile devices by marking the hidden `<model-viewer>` element with `ar` attributes
- remove unused `canActivateAR` check and rely on `activateAR()` with graceful fallback
- delay mesh swap until the new model finishes loading and keep the loading overlay until UI and scene are ready
- use WebXR on Android and wait for interface readiness while showing a progress bar during startup
- show centered loading overlays and export iOS USDZ via Quick Look
- restore Android Scene Viewer intent and direct iOS Quick Look launch without scaling
- show a text-only overlay while preparing the AR scene
- route Android AR through WebXR model-viewer and skip GLB generation on iOS
- launch Android AR on the first tap and open iOS Quick Look via a rel="ar" anchor
- add QR sharing for desktop, replacing the AR button with a code that preserves slot selections
- constrain QR overlay size and regenerate codes whenever selection changes
- load QRCode as an ES module to prevent browser `require` errors
- consolidate three.js imports to prevent duplicate instances
- tighten QR overlay styling so the panel fits its content instead of spanning the viewer width
- fix QRCode CDN import to avoid 404 errors

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895693faecc8322bc8546c552325c84